### PR TITLE
Prevent country change when dial code or area-code is not changed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/jest.config.json
+++ b/jest.config.json
@@ -18,5 +18,6 @@
     "!**/*stories.{ts,tsx}",
     "!<rootDir>/src/utils/test-utils.ts"
   ],
-  "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"]
+  "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"],
+  "testTimeout": 100000
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,9 +15,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "2.2.0",
-    "@docusaurus/preset-classic": "2.2.0",
-    "@docusaurus/theme-common": "^2.2.0",
+    "@docusaurus/core": "2.3.1",
+    "@docusaurus/preset-classic": "2.3.1",
+    "@docusaurus/theme-common": "^2.3.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
@@ -26,13 +26,13 @@
     "react-international-phone": "workspace:^"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.2.0",
-    "@docusaurus/types": "^2.2.0",
-    "@tsconfig/docusaurus": "^1.0.5",
-    "docusaurus-plugin-sass": "^0.2.2",
+    "@docusaurus/module-type-aliases": "2.3.1",
+    "@docusaurus/types": "^2.3.1",
+    "@tsconfig/docusaurus": "^1.0.6",
+    "docusaurus-plugin-sass": "^0.2.3",
     "sass": "^1.55.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.4"
   },
   "browserslist": {
     "production": [

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -29,6 +29,7 @@ const HomepageHeader: React.FC = () => {
         >
           <PhoneInput
             initialCountry="ua"
+            placeholder="Phone number"
             inputProps={{
               autoFocus: true,
             }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,26 +148,26 @@ importers:
 
   packages/docs:
     specifiers:
-      '@docusaurus/core': 2.2.0
-      '@docusaurus/module-type-aliases': 2.2.0
-      '@docusaurus/preset-classic': 2.2.0
-      '@docusaurus/theme-common': ^2.2.0
-      '@docusaurus/types': ^2.2.0
+      '@docusaurus/core': 2.3.1
+      '@docusaurus/module-type-aliases': 2.3.1
+      '@docusaurus/preset-classic': 2.3.1
+      '@docusaurus/theme-common': ^2.3.1
+      '@docusaurus/types': ^2.3.1
       '@mdx-js/react': ^1.6.22
-      '@tsconfig/docusaurus': ^1.0.5
+      '@tsconfig/docusaurus': ^1.0.6
       clsx: ^1.2.1
-      docusaurus-plugin-sass: ^0.2.2
+      docusaurus-plugin-sass: ^0.2.3
       prism-react-renderer: ^1.3.5
       react: ^17.0.2
       react-dom: ^17.0.2
       react-international-phone: workspace:^
       sass: ^1.55.0
       ts-node: ^10.9.1
-      typescript: ^4.7.4
+      typescript: ^4.9.4
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/preset-classic': 2.2.0_65e6vsojdhusq2wqqiy3kus3ju
-      '@docusaurus/theme-common': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/preset-classic': 2.3.1_65e6vsojdhusq2wqqiy3kus3ju
+      '@docusaurus/theme-common': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
       '@mdx-js/react': 1.6.22_react@17.0.2
       clsx: 1.2.1
       prism-react-renderer: 1.3.5_react@17.0.2
@@ -175,10 +175,10 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       react-international-phone: link:../..
     devDependencies:
-      '@docusaurus/module-type-aliases': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/module-type-aliases': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
       '@tsconfig/docusaurus': 1.0.6
-      docusaurus-plugin-sass: 0.2.3_l6y7ssy3hzoo5jia42frfjhh3y
+      docusaurus-plugin-sass: 0.2.3_udccz5qpel6brr5yu5offanrhm
       sass: 1.57.1
       ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
       typescript: 4.9.4
@@ -2757,8 +2757,8 @@ packages:
       - '@algolia/client-search'
     dev: false
 
-  /@docusaurus/core/2.2.0_vukvsfkp4hxnee7vteliqou2xy:
-    resolution: {integrity: sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==}
+  /@docusaurus/core/2.3.1_6kvjorquc6h4ilj2zujchaxz5u:
+    resolution: {integrity: sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==}
     engines: {node: '>=16.14'}
     hasBin: true
     peerDependencies:
@@ -2775,13 +2775,13 @@ packages:
       '@babel/runtime': 7.20.13
       '@babel/runtime-corejs3': 7.20.13
       '@babel/traverse': 7.20.13
-      '@docusaurus/cssnano-preset': 2.2.0
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/mdx-loader': 2.2.0_zneentkx4scexj4pzosurqq55y
+      '@docusaurus/cssnano-preset': 2.3.1
+      '@docusaurus/logger': 2.3.1
+      '@docusaurus/mdx-loader': 2.3.1_nucoingj6jnpt355a2yzaplk5e
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-common': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-common': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13_postcss@8.4.21
@@ -2802,7 +2802,7 @@ packages:
       del: 6.1.1
       detect-port: 1.5.1
       escape-html: 1.0.3
-      eta: 1.14.2
+      eta: 2.0.0
       file-loader: 6.2.0_webpack@5.75.0
       fs-extra: 10.1.0
       html-minifier-terser: 6.1.0
@@ -2856,8 +2856,8 @@ packages:
       - vue-template-compiler
       - webpack-cli
 
-  /@docusaurus/cssnano-preset/2.2.0:
-    resolution: {integrity: sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==}
+  /@docusaurus/cssnano-preset/2.3.1:
+    resolution: {integrity: sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==}
     engines: {node: '>=16.14'}
     dependencies:
       cssnano-preset-advanced: 5.3.9_postcss@8.4.21
@@ -2865,15 +2865,15 @@ packages:
       postcss-sort-media-queries: 4.3.0_postcss@8.4.21
       tslib: 2.5.0
 
-  /@docusaurus/logger/2.2.0:
-    resolution: {integrity: sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==}
+  /@docusaurus/logger/2.3.1:
+    resolution: {integrity: sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==}
     engines: {node: '>=16.14'}
     dependencies:
       chalk: 4.1.2
       tslib: 2.5.0
 
-  /@docusaurus/mdx-loader/2.2.0_zneentkx4scexj4pzosurqq55y:
-    resolution: {integrity: sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==}
+  /@docusaurus/mdx-loader/2.3.1_nucoingj6jnpt355a2yzaplk5e:
+    resolution: {integrity: sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
@@ -2881,8 +2881,8 @@ packages:
     dependencies:
       '@babel/parser': 7.20.13
       '@babel/traverse': 7.20.13
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/logger': 2.3.1
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
       '@mdx-js/mdx': 1.6.22
       escape-html: 1.0.3
       file-loader: 6.2.0_webpack@5.75.0
@@ -2906,14 +2906,14 @@ packages:
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/module-type-aliases/2.2.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==}
+  /@docusaurus/module-type-aliases/2.3.1_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==}
     peerDependencies:
       react: '*'
       react-dom: '*'
     dependencies:
       '@docusaurus/react-loadable': 5.5.2_react@17.0.2
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
       '@types/history': 4.7.11
       '@types/react': 18.0.27
       '@types/react-router-config': 5.0.6
@@ -2928,20 +2928,20 @@ packages:
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/plugin-content-blog/2.2.0_lhsnqlb35hvawm3f6bviuzo2eu:
-    resolution: {integrity: sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==}
+  /@docusaurus/plugin-content-blog/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/mdx-loader': 2.2.0_zneentkx4scexj4pzosurqq55y
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-common': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/logger': 2.3.1
+      '@docusaurus/mdx-loader': 2.3.1_nucoingj6jnpt355a2yzaplk5e
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-common': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 10.1.0
@@ -2971,20 +2971,20 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-docs/2.2.0_lhsnqlb35hvawm3f6bviuzo2eu:
-    resolution: {integrity: sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==}
+  /@docusaurus/plugin-content-docs/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/mdx-loader': 2.2.0_zneentkx4scexj4pzosurqq55y
-      '@docusaurus/module-type-aliases': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/logger': 2.3.1
+      '@docusaurus/mdx-loader': 2.3.1_nucoingj6jnpt355a2yzaplk5e
+      '@docusaurus/module-type-aliases': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       '@types/react-router-config': 5.0.6
       combine-promises: 1.1.0
       fs-extra: 10.1.0
@@ -3014,18 +3014,18 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-pages/2.2.0_lhsnqlb35hvawm3f6bviuzo2eu:
-    resolution: {integrity: sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==}
+  /@docusaurus/plugin-content-pages/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/mdx-loader': 2.2.0_zneentkx4scexj4pzosurqq55y
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/mdx-loader': 2.3.1_nucoingj6jnpt355a2yzaplk5e
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3049,16 +3049,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-debug/2.2.0_lhsnqlb35hvawm3f6bviuzo2eu:
-    resolution: {integrity: sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==}
+  /@docusaurus/plugin-debug/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3084,16 +3084,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-analytics/2.2.0_lhsnqlb35hvawm3f6bviuzo2eu:
-    resolution: {integrity: sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==}
+  /@docusaurus/plugin-google-analytics/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       tslib: 2.5.0
@@ -3115,16 +3115,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-gtag/2.2.0_lhsnqlb35hvawm3f6bviuzo2eu:
-    resolution: {integrity: sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==}
+  /@docusaurus/plugin-google-gtag/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       tslib: 2.5.0
@@ -3146,19 +3146,50 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-sitemap/2.2.0_lhsnqlb35hvawm3f6bviuzo2eu:
-    resolution: {integrity: sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==}
+  /@docusaurus/plugin-google-tag-manager/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-common': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tslib: 2.5.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/plugin-sitemap/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/logger': 2.3.1
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-common': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3182,25 +3213,26 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic/2.2.0_65e6vsojdhusq2wqqiy3kus3ju:
-    resolution: {integrity: sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==}
+  /@docusaurus/preset-classic/2.3.1_65e6vsojdhusq2wqqiy3kus3ju:
+    resolution: {integrity: sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/plugin-content-blog': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-content-docs': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-content-pages': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-debug': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-google-analytics': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-google-gtag': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-sitemap': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/theme-classic': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/theme-common': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/theme-search-algolia': 2.2.0_yov7hf7zrbhu4gxl7psaulskqy
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/plugin-content-blog': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-content-docs': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-content-pages': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-debug': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-google-analytics': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-google-gtag': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-google-tag-manager': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-sitemap': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/theme-classic': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/theme-common': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/theme-search-algolia': 2.3.1_ibsa4oga5d5jzdnepshxtg42e4
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
@@ -3233,25 +3265,25 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
 
-  /@docusaurus/theme-classic/2.2.0_lhsnqlb35hvawm3f6bviuzo2eu:
-    resolution: {integrity: sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==}
+  /@docusaurus/theme-classic/2.3.1_lhsnqlb35hvawm3f6bviuzo2eu:
+    resolution: {integrity: sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/mdx-loader': 2.2.0_zneentkx4scexj4pzosurqq55y
-      '@docusaurus/module-type-aliases': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-blog': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-content-docs': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-content-pages': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/theme-common': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/theme-translations': 2.2.0
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-common': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/mdx-loader': 2.3.1_nucoingj6jnpt355a2yzaplk5e
+      '@docusaurus/module-type-aliases': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-content-docs': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-content-pages': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/theme-common': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/theme-translations': 2.3.1
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-common': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       '@mdx-js/react': 1.6.22_react@17.0.2
       clsx: 1.2.1
       copy-text-to-clipboard: 3.0.1
@@ -3285,19 +3317,19 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-common/2.2.0_vukvsfkp4hxnee7vteliqou2xy:
-    resolution: {integrity: sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==}
+  /@docusaurus/theme-common/2.3.1_6kvjorquc6h4ilj2zujchaxz5u:
+    resolution: {integrity: sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/mdx-loader': 2.2.0_zneentkx4scexj4pzosurqq55y
-      '@docusaurus/module-type-aliases': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
-      '@docusaurus/plugin-content-blog': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-content-docs': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/plugin-content-pages': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/mdx-loader': 2.3.1_nucoingj6jnpt355a2yzaplk5e
+      '@docusaurus/module-type-aliases': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/plugin-content-blog': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-content-docs': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/plugin-content-pages': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
       '@types/history': 4.7.11
       '@types/react': 18.0.27
       '@types/react-router-config': 5.0.6
@@ -3307,6 +3339,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       tslib: 2.5.0
+      use-sync-external-store: 1.2.0_react@17.0.2
       utility-types: 3.10.0
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -3327,25 +3360,25 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia/2.2.0_yov7hf7zrbhu4gxl7psaulskqy:
-    resolution: {integrity: sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==}
+  /@docusaurus/theme-search-algolia/2.3.1_ibsa4oga5d5jzdnepshxtg42e4:
+    resolution: {integrity: sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
       '@docsearch/react': 3.3.2_p2wvewccyj6enzdqwvxe7poqlq
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/plugin-content-docs': 2.2.0_lhsnqlb35hvawm3f6bviuzo2eu
-      '@docusaurus/theme-common': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
-      '@docusaurus/theme-translations': 2.2.0
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
-      '@docusaurus/utils-validation': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/logger': 2.3.1
+      '@docusaurus/plugin-content-docs': 2.3.1_lhsnqlb35hvawm3f6bviuzo2eu
+      '@docusaurus/theme-common': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
+      '@docusaurus/theme-translations': 2.3.1
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
+      '@docusaurus/utils-validation': 2.3.1_@docusaurus+types@2.3.1
       algoliasearch: 4.14.3
       algoliasearch-helper: 3.11.3_algoliasearch@4.14.3
       clsx: 1.2.1
-      eta: 1.14.2
+      eta: 2.0.0
       fs-extra: 10.1.0
       lodash: 4.17.21
       react: 17.0.2
@@ -3373,16 +3406,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-translations/2.2.0:
-    resolution: {integrity: sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==}
+  /@docusaurus/theme-translations/2.3.1:
+    resolution: {integrity: sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==}
     engines: {node: '>=16.14'}
     dependencies:
       fs-extra: 10.1.0
       tslib: 2.5.0
     dev: false
 
-  /@docusaurus/types/2.2.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==}
+  /@docusaurus/types/2.3.1_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
@@ -3403,8 +3436,8 @@ packages:
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/utils-common/2.2.0_@docusaurus+types@2.2.0:
-    resolution: {integrity: sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==}
+  /@docusaurus/utils-common/2.3.1_@docusaurus+types@2.3.1:
+    resolution: {integrity: sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==}
     engines: {node: '>=16.14'}
     peerDependencies:
       '@docusaurus/types': '*'
@@ -3412,15 +3445,15 @@ packages:
       '@docusaurus/types':
         optional: true
     dependencies:
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
       tslib: 2.5.0
 
-  /@docusaurus/utils-validation/2.2.0_@docusaurus+types@2.2.0:
-    resolution: {integrity: sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==}
+  /@docusaurus/utils-validation/2.3.1_@docusaurus+types@2.3.1:
+    resolution: {integrity: sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/utils': 2.2.0_@docusaurus+types@2.2.0
+      '@docusaurus/logger': 2.3.1
+      '@docusaurus/utils': 2.3.1_@docusaurus+types@2.3.1
       joi: 17.7.0
       js-yaml: 4.1.0
       tslib: 2.5.0
@@ -3432,8 +3465,8 @@ packages:
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/utils/2.2.0_@docusaurus+types@2.2.0:
-    resolution: {integrity: sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==}
+  /@docusaurus/utils/2.3.1_@docusaurus+types@2.3.1:
+    resolution: {integrity: sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       '@docusaurus/types': '*'
@@ -3441,9 +3474,10 @@ packages:
       '@docusaurus/types':
         optional: true
     dependencies:
-      '@docusaurus/logger': 2.2.0
-      '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
+      '@docusaurus/logger': 2.3.1
+      '@docusaurus/types': 2.3.1_sfoxds7t5ydpegc3knd667wn6m
       '@svgr/webpack': 6.5.1
+      escape-string-regexp: 4.0.0
       file-loader: 6.2.0_webpack@5.75.0
       fs-extra: 10.1.0
       github-slugger: 1.5.0
@@ -6320,7 +6354,7 @@ packages:
   /@types/sax/1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.11.18
     dev: false
 
   /@types/scheduler/0.16.2:
@@ -7489,7 +7523,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.75.0_webpack-cli@5.0.1
+      webpack: 5.75.0
 
   /babel-loader/8.3.0_nwtvwtk5tmh22l2urnqucz7kqu:
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
@@ -9418,13 +9452,13 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /docusaurus-plugin-sass/0.2.3_l6y7ssy3hzoo5jia42frfjhh3y:
+  /docusaurus-plugin-sass/0.2.3_udccz5qpel6brr5yu5offanrhm:
     resolution: {integrity: sha512-FbaE06K8NF8SPUYTwiG+83/jkXrwHJ/Afjqz3SUIGon6QvFwSSoKOcoxGQmUBnjTOk+deUONDx8jNWsegFJcBQ==}
     peerDependencies:
       '@docusaurus/core': ^2.0.0-beta
       sass: ^1.30.0
     dependencies:
-      '@docusaurus/core': 2.2.0_vukvsfkp4hxnee7vteliqou2xy
+      '@docusaurus/core': 2.3.1_6kvjorquc6h4ilj2zujchaxz5u
       sass: 1.57.1
       sass-loader: 10.4.1_sass@1.57.1+webpack@5.75.0
     transitivePeerDependencies:
@@ -10018,8 +10052,8 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  /eta/1.14.2:
-    resolution: {integrity: sha512-wZmJAV7EFUG5W8XNXSazIdichnWEhGB1OWg4tnXWPj0CPNUcFdgorGNO6N9p6WBUgoUe4P0OziJYn1+6zxP2aQ==}
+  /eta/2.0.0:
+    resolution: {integrity: sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA==}
     engines: {node: '>=6.0.0'}
 
   /etag/1.8.1:
@@ -11436,7 +11470,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.75.0_webpack-cli@5.0.1
+      webpack: 5.75.0
 
   /htmlparser2/6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -18153,7 +18187,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.1
       terser: 5.16.1
-      webpack: 5.75.0_webpack-cli@5.0.1
+      webpack: 5.75.0
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -18880,6 +18914,14 @@ packages:
       react: 17.0.2
       tslib: 2.5.0
     dev: true
+
+  /use-sync-external-store/1.2.0_react@17.0.2:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 17.0.2
+    dev: false
 
   /use/3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}

--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -91,6 +91,29 @@ describe('PhoneInput', () => {
     expect(getCountrySelector()).toHaveAttribute('data-country', 'us');
   });
 
+  test('should not change the country when dial code or area-code is not changed', () => {
+    // Canada and USA have "+1" as dial code
+    render(<PhoneInput initialCountry="ca" />);
+
+    fireEvent.change(getInput(), { target: { value: '+12' } });
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'ca');
+
+    fireEvent.change(getInput(), { target: { value: '+123' } });
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'ca');
+
+    fireEvent.change(getInput(), { target: { value: '+1234' } });
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'ca');
+
+    fireEvent.change(getInput(), { target: { value: '+1203' } });
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'us');
+
+    fireEvent.change(getInput(), { target: { value: '+1204' } });
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'ca');
+
+    fireEvent.change(getInput(), { target: { value: '+1' } });
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'ca');
+  });
+
   test('should open country selector dropdown', () => {
     render(<PhoneInput initialCountry="ua" />);
     expect(getCountrySelectorDropdown()).not.toBeVisible();
@@ -104,6 +127,19 @@ describe('PhoneInput', () => {
     fireEvent.click(getDropdownOption('af'));
     expect(getCountrySelector()).toHaveAttribute('data-country', 'af');
     expect(getInput().value).toBe('+93 ');
+
+    fireEvent.click(getCountrySelector());
+    fireEvent.click(getDropdownOption('us'));
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'us');
+    expect(getInput().value).toBe('+1 ');
+
+    fireEvent.change(getInput(), { target: { value: '+1234' } });
+    expect(getInput().value).toBe('+1 (234) ');
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'us');
+
+    fireEvent.click(getCountrySelector());
+    fireEvent.click(getDropdownOption('ca'));
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'ca');
   });
 
   test('should support disabled state', () => {

--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { defaultCountries } from '../../data/countryData';
-import { parseCountry } from '../../utils';
+import { parseCountry, removeNonDigits } from '../../utils';
 import { buildCountryData } from '../../utils/countryUtils/buildCountryData';
 import {
   getCountrySelector,
@@ -642,5 +642,36 @@ describe('PhoneInput', () => {
       expect(getInput().selectionStart).toBe('+31 '.length);
       expect(getInput().selectionEnd).toBe('+31 '.length);
     });
+  });
+
+  test('should use default mask if country data does not have mask', () => {
+    render(<PhoneInput initialCountry="do" />);
+    fireChangeEvent('+1234567');
+    expect(getInput().value).toBe('+1 234567');
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'do');
+  });
+
+  test('should work with every country', () => {
+    render(
+      <PhoneInput initialCountry={parseCountry(defaultCountries[0]).iso2} />,
+    );
+
+    for (const c of defaultCountries) {
+      const country = parseCountry(c);
+
+      // change country using dropdown
+      fireEvent.click(getCountrySelector());
+      fireEvent.click(getDropdownOption(country.iso2));
+
+      const userInput = '999999';
+      const inputValue = `${country.dialCode}${userInput}`;
+      fireChangeEvent(inputValue);
+
+      expect(removeNonDigits(getInput().value)).toBe(inputValue);
+      expect(getCountrySelector()).toHaveAttribute(
+        'data-country',
+        country.iso2,
+      );
+    }
   });
 });

--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -68,8 +68,15 @@ describe('PhoneInput', () => {
   });
 
   test('should set flag to country selector', () => {
-    render(<PhoneInput value="+380" initialCountry="ua" />);
-    expect(getCountrySelector()).toHaveAttribute('title', 'Ukraine');
+    const { rerender } = render(<PhoneInput value="+1" initialCountry="ca" />);
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'ca');
+    expect(getCountrySelector()).toHaveAttribute('title', 'Canada');
+
+    rerender(<PhoneInput value="+1 (201)" initialCountry="ca" />);
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'us');
+
+    rerender(<PhoneInput value="+380 (99) 999 99 99" initialCountry="ca" />);
+    expect(getCountrySelector()).toHaveAttribute('data-country', 'ua');
   });
 
   test('should format value', () => {

--- a/src/data/countryData.ts
+++ b/src/data/countryData.ts
@@ -212,7 +212,7 @@ export const defaultCountries: CountryData[] = [
     'kz',
     '7',
     '... ...-..-..',
-    1,
+    0,
     [
       '310',
       '311',
@@ -311,7 +311,7 @@ export const defaultCountries: CountryData[] = [
     'ru',
     '7',
     '(...) ...-..-..',
-    0,
+    1,
   ],
   ['Rwanda', ['africa'], 'rw', '250'],
   ['Saint Kitts and Nevis', ['america', 'carribean'], 'kn', '1869'],

--- a/src/hooks/usePhone.ts
+++ b/src/hooks/usePhone.ts
@@ -199,6 +199,21 @@ export const usePhone = (value: string, config?: UsePhoneConfig) => {
           }) // FIXME: should not guess country on every change
         : undefined;
 
+    // save the passed country if the dial code is the same
+    const shouldSaveDialCode =
+      !!countryGuessResult &&
+      !!passedCountry &&
+      // different countries with same dial code
+      countryGuessResult.country?.dialCode === passedCountry.dialCode &&
+      countryGuessResult.country !== passedCountry &&
+      // full dial code match (without area code)
+      countryGuessResult.fullDialCodeMatch &&
+      !countryGuessResult.areaCodeMatch;
+
+    if (shouldSaveDialCode) {
+      countryGuessResult.country = passedCountry;
+    }
+
     const formatCountry =
       !forceDisableCountryGuess && shouldGuessCountry
         ? countryGuessResult?.country ?? passedCountry

--- a/src/hooks/usePhone.ts
+++ b/src/hooks/usePhone.ts
@@ -222,7 +222,7 @@ export const usePhone = (value: string, config?: UsePhoneConfig) => {
     const phone = formatCountry
       ? formatPhone(value, {
           prefix,
-          mask: formatCountry.format ?? defaultMask,
+          mask: formatCountry.format || defaultMask,
           maskChar: MASK_CHAR,
           dialCode: formatCountry.dialCode,
           trimNonDigitsEnd,

--- a/src/hooks/usePhone.ts
+++ b/src/hooks/usePhone.ts
@@ -196,23 +196,9 @@ export const usePhone = (value: string, config?: UsePhoneConfig) => {
         ? guessCountryByPartialNumber({
             phone: value,
             countries: countryData,
+            currentCountryIso2: passedCountry?.iso2,
           }) // FIXME: should not guess country on every change
         : undefined;
-
-    // save the passed country if the dial code is the same
-    const shouldSaveDialCode =
-      !!countryGuessResult &&
-      !!passedCountry &&
-      // different countries with same dial code
-      countryGuessResult.country?.dialCode === passedCountry.dialCode &&
-      countryGuessResult.country !== passedCountry &&
-      // full dial code match (without area code)
-      countryGuessResult.fullDialCodeMatch &&
-      !countryGuessResult.areaCodeMatch;
-
-    if (shouldSaveDialCode) {
-      countryGuessResult.country = passedCountry;
-    }
 
     const formatCountry =
       !forceDisableCountryGuess && shouldGuessCountry

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -62,8 +62,11 @@ export const usePhoneInput = ({
   });
 
   const [country, setCountry] = useState<CountryIso2>(
-    guessCountryByPartialNumber({ phone: value, countries }).country?.iso2 ??
-      initialCountry,
+    guessCountryByPartialNumber({
+      phone: value,
+      countries,
+      currentCountryIso2: initialCountry,
+    }).country?.iso2 ?? initialCountry,
   );
 
   const passedCountry = useMemo(() => {

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -230,7 +230,14 @@ export const usePhoneInput = ({
       shouldSetCursorToEnd: true,
     };
 
-    const newValue = handleValueChange(newCountry.dialCode);
+    const newValue = handleValueChange(
+      disableDialCodeAndPrefix
+        ? ''
+        : `${prefix}${charAfterDialCode}${newCountry.dialCode}`,
+      {
+        forcedCountry: newCountry,
+      },
+    );
     setCountry(newCountry.iso2);
 
     onCountryChange?.(newValue);

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -8,7 +8,6 @@ import {
   getCursorPosition,
   guessCountryByPartialNumber,
   removeDialCode,
-  removeNonDigits,
 } from '../utils';
 import { usePhone, UsePhoneConfig } from './usePhone';
 
@@ -52,6 +51,15 @@ export const usePhoneInput = ({
   ...restConfig
 }: UsePhoneInputConfig) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // store info in ref to pass it to onPhoneUpdate callback
+  const onPhoneUpdateRef = useRef<{
+    shouldFocus: boolean;
+    shouldSetCursorToEnd: boolean;
+  }>({
+    shouldFocus: false,
+    shouldSetCursorToEnd: false,
+  });
 
   const [country, setCountry] = useState<CountryIso2>(
     guessCountryByPartialNumber({ phone: value, countries }).country?.iso2 ??
@@ -101,7 +109,10 @@ export const usePhoneInput = ({
           deletion,
         },
       ) => {
-        const cursorPosition = initialized
+        const shouldGetCursorPosition =
+          initialized && !onPhoneUpdateRef.current.shouldSetCursorToEnd;
+
+        const cursorPosition = shouldGetCursorPosition
           ? getCursorPosition({
               cursorPositionAfterInput,
               phoneBeforeInput: phone,
@@ -122,6 +133,15 @@ export const usePhoneInput = ({
          */
         Promise.resolve().then(() => {
           inputRef.current?.setSelectionRange(cursorPosition, cursorPosition);
+
+          if (onPhoneUpdateRef.current.shouldFocus) {
+            inputRef.current?.focus();
+          }
+
+          onPhoneUpdateRef.current = {
+            shouldFocus: false,
+            shouldSetCursorToEnd: false,
+          };
         });
       },
       ...restConfig,
@@ -192,27 +212,32 @@ export const usePhoneInput = ({
     return value;
   };
 
-  // Handle country change
-  useEffect(() => {
-    if (!passedCountry || !initialized) return;
+  const setNewCountry = (countryIso2: CountryIso2) => {
+    const newCountry = getCountry({
+      value: countryIso2,
+      field: 'iso2',
+      countries,
+    });
+    if (!newCountry) return;
 
-    if (removeNonDigits(phone).startsWith(passedCountry.dialCode)) {
-      // country was changed using input field
-      return;
-    }
+    // need to call focus inside a onPhoneUpdate callback
+    // because we need to wait phone-input's rerender to set focus properly
+    onPhoneUpdateRef.current = {
+      shouldFocus: true,
+      shouldSetCursorToEnd: true,
+    };
 
-    const newValue = handleValueChange('', { insertDialCodeOnEmpty: true });
-    inputRef.current?.focus();
+    const newValue = handleValueChange(newCountry.dialCode);
+    setCountry(newCountry.iso2);
 
     onCountryChange?.(newValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [country]);
+  };
 
   return {
     phone, // Formatted phone string.
     handlePhoneValueChange, // Change handler for input component
     inputRef, // Ref object for input component (handles caret position, focus and undo/redo).
     country, // Current country iso code.
-    setCountry, // Country setter.
+    setCountry: setNewCountry, // Country setter.
   };
 };

--- a/src/stories/Demo.stories.tsx
+++ b/src/stories/Demo.stories.tsx
@@ -109,3 +109,9 @@ export const RerenderTest = () => {
     </div>
   );
 };
+
+export const ControlledInputTest = () => {
+  const [phone, setPhone] = useState('+1 ');
+
+  return <PhoneInput value={phone} onChange={setPhone} initialCountry="ca" />;
+};

--- a/src/stories/UiLibsExample/components/AntPhone.tsx
+++ b/src/stories/UiLibsExample/components/AntPhone.tsx
@@ -53,6 +53,8 @@ export const AntPhone: React.FC<AntPhoneProps> = ({ value, onChange }) => {
           }}
         />
         <Input
+          placeholder="Phone number"
+          type="tel"
           value={phoneInput.phone}
           onChange={(e) => {
             const value = phoneInput.handlePhoneValueChange(e);

--- a/src/stories/UiLibsExample/components/ChakraPhone.tsx
+++ b/src/stories/UiLibsExample/components/ChakraPhone.tsx
@@ -32,6 +32,7 @@ export const ChakraPhone: React.FC<ChakraPhoneProps> = ({
         />
         <Input
           placeholder="Phone number"
+          type="tel"
           color="primary"
           value={phoneInput.phone}
           onChange={(e) => {

--- a/src/stories/Validation.stories.tsx
+++ b/src/stories/Validation.stories.tsx
@@ -99,7 +99,7 @@ export const Formik = () => {
       if (!validationResult.lengthMatch) {
         errors.phone = 'wrong phone length';
       }
-      if (!validationResult.areaCodeMatch) {
+      if (validationResult.areaCodeMatch === false) {
         errors.phone = 'wrong area code';
       }
       if (!validationResult.country) {

--- a/src/utils/countryUtils/__tests__/guessCountryByPartialNumber.test.ts
+++ b/src/utils/countryUtils/__tests__/guessCountryByPartialNumber.test.ts
@@ -201,4 +201,28 @@ describe('guessCountryByPartialNumber', () => {
       areaCodeMatch: undefined,
     });
   });
+
+  test('should return the current country if the dial code matches', () => {
+    expect(
+      guessCountryByPartialNumber({
+        phone: '+1 234567890',
+        countries: defaultCountries,
+        currentCountryIso2: 'do',
+      }),
+    ).toMatchObject({
+      country: { dialCode: '1', iso2: 'do' },
+      areaCodeMatch: false,
+    });
+
+    expect(
+      guessCountryByPartialNumber({
+        phone: '+1 204567890', // Canada area code
+        countries: defaultCountries,
+        currentCountryIso2: 'do',
+      }),
+    ).toMatchObject({
+      country: { dialCode: '1', iso2: 'ca' },
+      areaCodeMatch: true,
+    });
+  });
 });

--- a/src/utils/countryUtils/guessCountryByPartialNumber.ts
+++ b/src/utils/countryUtils/guessCountryByPartialNumber.ts
@@ -1,13 +1,21 @@
-import { CountryData, CountryGuessResult, ParsedCountry } from '../../types';
+import {
+  CountryData,
+  CountryGuessResult,
+  CountryIso2,
+  ParsedCountry,
+} from '../../types';
 import { removeNonDigits } from '../common';
+import { getCountry } from './getCountry';
 import { parseCountry } from './parseCountry';
 
 export const guessCountryByPartialNumber = ({
   phone: partialPhone,
   countries,
+  currentCountryIso2,
 }: {
   phone: string;
   countries: CountryData[];
+  currentCountryIso2?: CountryIso2;
 }): CountryGuessResult => {
   const emptyResult = {
     country: undefined,
@@ -97,6 +105,29 @@ export const guessCountryByPartialNumber = ({
           updateResult({ country: parsedCountry, fullDialCodeMatch: false });
         }
       }
+    }
+  }
+
+  if (currentCountryIso2) {
+    const currentCountry = getCountry({
+      value: currentCountryIso2,
+      field: 'iso2',
+      countries,
+    });
+
+    // save the passed country if the dial code is the same
+    const shouldSaveDialCode =
+      !!result &&
+      !!currentCountry &&
+      // different countries with same dial code
+      result.country?.dialCode === currentCountry.dialCode &&
+      result.country !== currentCountry &&
+      // full dial code match (without area code)
+      result.fullDialCodeMatch &&
+      !result.areaCodeMatch;
+
+    if (shouldSaveDialCode) {
+      result.country = currentCountry;
     }
   }
 


### PR DESCRIPTION
## What has been done
- Fixed set of the initial country flag when using controlled input
- Fixed country change when dial code or area-code is not changed
  - Fixed incorrect behavior when the value started with a dial code that is used by multiple countries.
- Fixed input bug with countries whose formatting mask is an empty string.