### PR TITLE
Handle `buildCountryData` args validation

### DIFF
--- a/packages/docs/docs/02-Usage/03-PhoneValidation.md
+++ b/packages/docs/docs/02-Usage/03-PhoneValidation.md
@@ -43,8 +43,8 @@ Validation behavior on countries with default masks can be slightly adjusted wit
 | areaCodeMatch | `boolean`                             | Is country area code exists.              |
 
 :::caution
-`isValid` is not guaranteed that entered phone number is 100% valid.
-When it becomes set to **true** it shows that country has been parsed from provided value, and the format mask of this country were applied correctly.
+`isValid` does not guarantee that the entered phone number is 100% valid.
+When `isValid` value becomes **true** it shows that the country was parsed from the provided phone value and that country's format mask was applied correctly.
 :::
 
 ### Basic Usage
@@ -87,7 +87,7 @@ const App = () => {
 ```
 
 :::tip
-Sometimes when you don't want to check area codes (e.g. you are not sure that area-codes array covers all the possible values) you can use `lengthMatch` to check the validation:
+Sometimes, when you don't want to check area codes (for example, you're not sure that the array of area codes covers all possible values), you can use `lengthMatch` to check the validation:
 
 ```tsx
 const phoneValidation = usePhoneValidation('+1 (123) 456-7890');

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,5 @@ export { PhoneInput } from './components/PhoneInput/PhoneInput';
 export { defaultCountries } from './data/countryData';
 export { usePhoneInput } from './hooks/usePhoneInput';
 export { usePhoneValidation } from './hooks/usePhoneValidation';
-export type { CountryIso2 } from './types';
+export type { CountryData, CountryIso2 } from './types';
 export { buildCountryData, parseCountry, validatePhone } from './utils';

--- a/src/stories/PhoneInput.stories.tsx
+++ b/src/stories/PhoneInput.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { PhoneInput } from '../components/PhoneInput/PhoneInput';
 import { defaultCountries } from '../data/countryData';
 import { CountryIso2 } from '../types';
-import { parseCountry } from '../utils';
+import { buildCountryData, parseCountry } from '../utils';
 
 export default {
   title: 'PhoneInput',
@@ -159,4 +159,23 @@ WithAutofocus.args = {
   inputProps: {
     autoFocus: true,
   },
+};
+
+export const E164Format = Template.bind({});
+E164Format.storyName = 'E164 Format';
+E164Format.argTypes = argTypes;
+
+const e164Countries = defaultCountries.map((c) => {
+  const country = parseCountry(c);
+  return buildCountryData({
+    ...country,
+    format: country.format?.replace(/[^\\.]*/g, ''), // remove all except dots
+  });
+});
+
+E164Format.args = {
+  defaultCountry: 'pt',
+  charAfterDialCode: '',
+  countries: e164Countries,
+  placeholder: 'Phone number',
 };

--- a/src/utils/countryUtils/__tests__/buildCountryData.test.ts
+++ b/src/utils/countryUtils/__tests__/buildCountryData.test.ts
@@ -68,4 +68,42 @@ describe('buildCountryData', () => {
     expect(country[5]).toEqual(undefined);
     expect(country[6]).toEqual(undefined);
   });
+
+  test('should bot allow create invalid countries', () => {
+    expect(() =>
+      buildCountryData({
+        name: 'Ukraine',
+        regions: [],
+        iso2: 'ua',
+        dialCode: '380',
+        format: undefined,
+        priority: 1,
+        areaCodes: undefined,
+      }),
+    ).toThrowError();
+
+    expect(() =>
+      buildCountryData({
+        name: 'Ukraine',
+        regions: [],
+        iso2: 'ua',
+        dialCode: '380',
+        format: undefined,
+        priority: undefined,
+        areaCodes: ['1'],
+      }),
+    ).toThrowError();
+
+    expect(() =>
+      buildCountryData({
+        name: 'Ukraine',
+        regions: [],
+        iso2: 'ua',
+        dialCode: '380',
+        format: '............',
+        priority: undefined,
+        areaCodes: ['1'],
+      }),
+    ).toThrowError();
+  });
 });

--- a/src/utils/countryUtils/buildCountryData.ts
+++ b/src/utils/countryUtils/buildCountryData.ts
@@ -12,7 +12,28 @@ export const buildCountryData = (parsedCountry: ParsedCountry): CountryData => {
     format,
     priority,
     areaCodes,
-  ].filter(Boolean) as CountryData;
+  ] as const;
 
-  return countryData;
+  // validate countryData array
+  for (let i = 0; i < countryData.length; i += 1) {
+    if (i === 0) continue; // skip first item
+
+    const prevValue = countryData[i - 1];
+    const currentValue = countryData[i];
+
+    // undefined values should go 1 by 1 in the end
+    // can not pass [..., 'data', undefined, 'data', ...]
+    if (prevValue === undefined && currentValue !== undefined) {
+      // JSON.stringify converts undefined to null
+      const stringifiedCountry = JSON.stringify(countryData, (_k, v) =>
+        v === undefined ? '__undefined' : v,
+      ).replace(/"__undefined"/g, 'undefined');
+
+      throw new Error(
+        `[react-international-phone] invalid country values passed to buildCountryData. Check ${prevValue} in: ${stringifiedCountry}`,
+      );
+    }
+  }
+
+  return countryData.filter((v) => v !== undefined) as CountryData;
 };


### PR DESCRIPTION
## What has been done
- `buildCountryData`
  - Fixed country data filtering
  - Added validation of passed country value
    - Fixes the problem mentioned in #37 
- Exported `CountryData` type from root
- docs: added e164 story, fixed typos on the docs website
