### PR TITLE
Fix the infinite loop issue when using with React 18

### DIFF
--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { defaultCountries } from '../data/countryData';
 import {
@@ -244,8 +244,6 @@ export const usePhoneInput = ({
     }) as ParsedCountry;
   }, [countries, country]);
 
-  const isInitializedRef = useRef(false);
-
   const handleValueChange = (
     newPhone: string,
     {
@@ -307,9 +305,7 @@ export const usePhoneInput = ({
     }
 
     const newCursorPosition = getCursorPosition({
-      cursorPositionAfterInput:
-        cursorPositionAfterInput ??
-        (isInitializedRef.current ? 0 : newPhone.length),
+      cursorPositionAfterInput: cursorPositionAfterInput ?? 0,
       phoneBeforeInput: phone,
       phoneAfterInput: newPhone,
       phoneAfterFormatted: phoneValue,
@@ -418,11 +414,14 @@ export const usePhoneInput = ({
     });
   };
 
+  const [initialized, setInitialized] = useState(false);
+
   // Handle value update
   useEffect(() => {
-    if (!isInitializedRef.current) {
+    if (!initialized) {
       // skip on initial render
-      isInitializedRef.current = true;
+      // initial value was set inside the useHistoryState call
+      setInitialized(true);
       return;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,7 +267,3 @@ export interface CountryGuessResult {
   fullDialCodeMatch: boolean;
   areaCodeMatch: boolean | undefined;
 }
-
-export type RequiredType<T> = {
-  [K in keyof T]: NonNullable<T[K]>;
-};


### PR DESCRIPTION
## What has been done
- Fixed infinite loop issue when passing empty string value to `usePhoneInput` on initial render
- Removed unused `RequiredType`