### PR TITLE
Make `defaultCountry` not required

### DIFF
--- a/packages/docs/docs/02-Usage/01-PhoneInput.md
+++ b/packages/docs/docs/02-Usage/01-PhoneInput.md
@@ -1,5 +1,3 @@
-import RequiredMark from '@site/src/components/RequiredMark'
-
 # PhoneInput API
 
 **PhoneInput** is a highly customizable phone input component.
@@ -26,31 +24,28 @@ Output:
 
 import {PhoneInput} from 'react-international-phone';
 
-<PhoneInput
-defaultCountry="ua"
-inputProps={{ autoFocus: true }}
-/>
+<PhoneInput defaultCountry="ua" />
 
 ## Properties
 
-| Prop                            | Type                  | Description                                                                                                                                                                                                          | Default value               |
-| ------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| defaultCountry <RequiredMark /> | `CountryIso2`         | Default country value (iso2).                                                                                                                                                                                        |                             |
-| value                           | `string`              | Phone value.                                                                                                                                                                                                         | `""`                        |
-| countries                       | `CountryData[]`       | An array of available countries to select (and guess)                                                                                                                                                                | `defaultCountries`          |
-| hideDropdown                    | `boolean`             | Hide the dropdown icon. Make country selection not accessible.                                                                                                                                                       | `false`                     |
-| placeholder                     | `string`              | Input's placeholder                                                                                                                                                                                                  | `undefined`                 |
-| disabled                        | `boolean`             | Disable phone input and country selector.                                                                                                                                                                            | `false`                     |
-| prefix                          | `string`              | Prefix for phone value.                                                                                                                                                                                              | `"+"`                       |
-| defaultMask                     | `string`              | This mask will apply on countries that does not have specified mask.                                                                                                                                                 | `"............"` (12 chars) |
-| charAfterDialCode               | `string`              | Char that renders after country dial code.                                                                                                                                                                           | ` `                         |
-| historySaveDebounceMS           | `number`              | Save value to history if there were not any changes in provided milliseconds timeslot.<br />Undo/redo (ctrl+z/ctrl+shift+z) works only with values that are saved in history                                         | `200`                       |
-| disableCountryGuess             | `boolean`             | Disable country guess on value change.<br />- _onCountryGuess_ callback would not be called.                                                                                                                         | `false`                     |
-| disableDialCodePrefill          | `boolean`             | Disable dial code prefill on initialization.<br />Dial code prefill works only when "empty" phone value have been provided.                                                                                          | `false`                     |
-| forceDialCode                   | `boolean`             | Always display the dial code.<br />Dial code can't be removed/changed by keyboard events, but it can be changed by pasting another country phone value.                                                              | `false`                     |
-| disableDialCodeAndPrefix        | `boolean`             | Phone value will not include passed _dialCode_ and _prefix_ if set to _true_.<br />- _disableCountryGuess_ value will be ignored and set to _true_.<br />- _forceDialCode_ value will be ignored and set to _false_. | `false`                     |
-| showDisabledDialCodeAndPrefix   | `boolean`             | Show prefix and dial code between country selector and phone input.<br />- Works only when _disableDialCodeAndPrefix_ is _true_                                                                                      | `false`                     |
-| inputProps                      | `InputHTMLAttributes` | Default input component props                                                                                                                                                                                        | `undefined`                 |
+| Prop                          | Type                  | Description                                                                                                                                                                                                          | Default value               |
+| ----------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| defaultCountry                | `CountryIso2`         | Default country value (iso2).                                                                                                                                                                                        | `"us"`                      |
+| value                         | `string`              | Phone value.                                                                                                                                                                                                         | `""`                        |
+| countries                     | `CountryData[]`       | An array of available countries to select (and guess)                                                                                                                                                                | `defaultCountries`          |
+| hideDropdown                  | `boolean`             | Hide the dropdown icon. Make country selection not accessible.                                                                                                                                                       | `false`                     |
+| placeholder                   | `string`              | Input's placeholder                                                                                                                                                                                                  | `undefined`                 |
+| disabled                      | `boolean`             | Disable phone input and country selector.                                                                                                                                                                            | `false`                     |
+| prefix                        | `string`              | Prefix for phone value.                                                                                                                                                                                              | `"+"`                       |
+| defaultMask                   | `string`              | This mask will apply on countries that does not have specified mask.                                                                                                                                                 | `"............"` (12 chars) |
+| charAfterDialCode             | `string`              | Char that renders after country dial code.                                                                                                                                                                           | ` `                         |
+| historySaveDebounceMS         | `number`              | Save value to history if there were not any changes in provided milliseconds timeslot.<br />Undo/redo (ctrl+z/ctrl+shift+z) works only with values that are saved in history                                         | `200`                       |
+| disableCountryGuess           | `boolean`             | Disable country guess on value change.<br />- _onCountryGuess_ callback would not be called.                                                                                                                         | `false`                     |
+| disableDialCodePrefill        | `boolean`             | Disable dial code prefill on initialization.<br />Dial code prefill works only when "empty" phone value have been provided.                                                                                          | `false`                     |
+| forceDialCode                 | `boolean`             | Always display the dial code.<br />Dial code can't be removed/changed by keyboard events, but it can be changed by pasting another country phone value.                                                              | `false`                     |
+| disableDialCodeAndPrefix      | `boolean`             | Phone value will not include passed _dialCode_ and _prefix_ if set to _true_.<br />- _disableCountryGuess_ value will be ignored and set to _true_.<br />- _forceDialCode_ value will be ignored and set to _false_. | `false`                     |
+| showDisabledDialCodeAndPrefix | `boolean`             | Show prefix and dial code between country selector and phone input.<br />- Works only when _disableDialCodeAndPrefix_ is _true_                                                                                      | `false`                     |
+| inputProps                    | `InputHTMLAttributes` | Default input component props                                                                                                                                                                                        | `undefined`                 |
 
 ## Events
 

--- a/packages/docs/docs/02-Usage/02-ModifyCountries.md
+++ b/packages/docs/docs/02-Usage/02-ModifyCountries.md
@@ -78,11 +78,16 @@ const [name, regions, iso2, dialCode, format, priority, areaCodes] =
 
 :::tip
 
-Also you can use `parseCountry` helper function to convert country data array to an object (as shown in example).
+You can use the `parseCountry` helper function to convert the country data array to an object, modify it in some way, and build back with `buildCountryData`
 
 ```ts
-const { name, regions, iso2, dialCode, format, priority, areaCodes } =
-  parseCountry(defaultCountries[0]);
+const lowercasedCountries = defaultCountries.map((country) => {
+  const parsedCountry = parseCountry(country);
+  // lowercase country names, for example
+  parsedCountry.name = parsedCountry.name.toLowerCase();
+
+  return buildCountryData(parsedCountry);
+});
 ```
 
 :::

--- a/packages/docs/docs/02-Usage/03-PhoneValidation.md
+++ b/packages/docs/docs/02-Usage/03-PhoneValidation.md
@@ -60,13 +60,14 @@ const App = () => {
   const phoneValidation = usePhoneValidation(phone);
   // highlight-end
 
-  const handleSubmit = () => {
-    // some submit logic
-    alert(`phone: ${phone}`);
-  };
-
   return (
-    <form>
+    <form
+      onSubmit={(e) => {
+        // some submit logic
+        e.preventDefault();
+        alert(`Submitted phone: ${phone}`);
+      }}
+    >
       <PhoneInput
         defaultCountry="ua"
         value={phone}
@@ -77,7 +78,6 @@ const App = () => {
         disabled={!phoneValidation.isValid}
         // highlight-end
         type="submit"
-        onClick={handleSubmit}
       >
         Submit
       </button>
@@ -85,6 +85,35 @@ const App = () => {
   );
 };
 ```
+
+import { useState } from 'react'
+import { PhoneInput, usePhoneValidation } from 'react-international-phone';
+
+export const Example = () => {
+const [phone, setPhone] = useState('');
+const phoneValidation = usePhoneValidation(phone);
+return (<form
+onSubmit={(e) => {
+e.preventDefault();
+alert(`Submitted phone: ${phone}`);
+}} >
+<PhoneInput
+defaultCountry="ua"
+value={phone}
+onChange={(phone) => setPhone(phone)}
+/>
+<button
+disabled={!phoneValidation.isValid}
+type="submit" >
+Submit
+</button></form>);
+};
+
+Output:
+
+<div style={{ margin: "8px 0 24px" }}>
+<Example />
+</div>
 
 :::tip
 Sometimes, when you don't want to check area codes (for example, you're not sure that the array of area codes covers all possible values), you can use `lengthMatch` to check the validation:

--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -321,6 +321,12 @@ describe('PhoneInput', () => {
       expect(getCountrySelector()).toHaveAttribute('data-country', 'ca');
       expect(getInput().value).toBe('+1 ');
     });
+
+    test('should set "us" if the default-country and value are not specified', () => {
+      render(<PhoneInput />);
+      expect(getCountrySelector()).toHaveAttribute('data-country', 'us');
+      expect(getInput().value).toBe('+1 ');
+    });
   });
 
   test('should render placeholder', () => {

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -39,11 +39,13 @@ export const MASK_CHAR = '.';
 export interface UsePhoneInputConfig {
   /**
    * @description Default country value (iso2).
+   * @default "us"
    */
-  defaultCountry: CountryIso2;
+  defaultCountry?: CountryIso2;
 
   /**
    * @description phone value
+   * @default ""
    */
   value?: string;
 
@@ -121,8 +123,9 @@ export interface UsePhoneInputConfig {
 }
 
 export const defaultConfig: Required<
-  Omit<UsePhoneInputConfig, 'defaultCountry' | 'onChange'> // omit props with no default value
+  Omit<UsePhoneInputConfig, 'onChange'> // omit props with no default value
 > = {
+  defaultCountry: 'us',
   value: '',
   prefix: '+',
   defaultMask: '............', // 12 chars
@@ -136,7 +139,7 @@ export const defaultConfig: Required<
 };
 
 export const usePhoneInput = ({
-  defaultCountry,
+  defaultCountry = defaultConfig.defaultCountry,
   value = defaultConfig.value,
   countries = defaultConfig.countries,
   prefix = defaultConfig.prefix,

--- a/src/stories/UiLibsExample/components/AntPhone.tsx
+++ b/src/stories/UiLibsExample/components/AntPhone.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, InputRef } from 'antd';
+import { Button, Input, InputRef, Space } from 'antd';
 import React, { useEffect, useRef } from 'react';
 
 import { CountrySelector, usePhoneInput } from '../../../index';
@@ -28,7 +28,7 @@ export const AntPhone: React.FC<AntPhoneProps> = ({ value, onChange }) => {
 
   return (
     <div style={{ display: 'flex', alignItems: 'center' }}>
-      <Input.Group compact>
+      <Space.Compact>
         <CountrySelector
           selectedCountry={phoneInput.country}
           onSelect={(country) => phoneInput.setCountry(country.iso2)}
@@ -36,13 +36,9 @@ export const AntPhone: React.FC<AntPhoneProps> = ({ value, onChange }) => {
             <Button
               {...rootProps}
               style={{
-                height: '32px',
                 padding: '4px',
-                // make the right border square
-                borderEndEndRadius: '0px',
-                borderStartEndRadius: '0px',
-                // fix on click effect overlap
-                zIndex: 1,
+                height: '100%',
+                zIndex: 1, // fix focus overlap
               }}
             >
               {children}
@@ -60,11 +56,8 @@ export const AntPhone: React.FC<AntPhoneProps> = ({ value, onChange }) => {
           value={phoneInput.phone}
           onChange={phoneInput.handlePhoneValueChange}
           ref={inputRef}
-          style={{
-            width: '200px',
-          }}
         />
-      </Input.Group>
+      </Space.Compact>
     </div>
   );
 };


### PR DESCRIPTION
## What has been done
- The `defaultCountry` prop is not required
  - set default value to `"us"`
- Small docs changes
  - Updated examples for `buildCountryData` and `usePhoneValidation`