### PR TITLE
Fix validation for countries with dial codes overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Find the full API reference on [official documentation](https://react-internatio
 ## Update from v1 to v2
 
 You can encounter some breaking changes after update from v1 to v2 <br/>
-Checkout [migration document](https://react-international-phone-docs.vercel.app/docs/migration) that contains a list of breaking changes and ways to migrate.
+Checkout [migration document](https://react-international-phone-docs.vercel.app/docs/Migrations/migrate-to-v2) that contains a list of breaking changes and ways to migrate.

--- a/packages/docs/docs/02-Usage/01-PhoneInput.md
+++ b/packages/docs/docs/02-Usage/01-PhoneInput.md
@@ -49,9 +49,9 @@ import {PhoneInput} from 'react-international-phone';
 
 ## Events
 
-| Event    | Type                      | Description                         |
-| -------- | ------------------------- | ----------------------------------- |
-| onChange | `(phone: string) => void` | Callback that calls on phone change |
+| Event    | Type                                            | Description                         |
+| -------- | ----------------------------------------------- | ----------------------------------- |
+| onChange | `(phone: string, country: CountryIso2) => void` | Callback that calls on phone change |
 
 Input events like **`onFocus`** and **`onBlur`** can be passed to the `inputProps`
 

--- a/packages/docs/docs/02-Usage/03-PhoneValidation.md
+++ b/packages/docs/docs/02-Usage/03-PhoneValidation.md
@@ -27,6 +27,7 @@ Validation behavior on countries with default masks can be slightly adjusted wit
 
 | Prop                      | Type            | Description                                                                                                                                            | Default value               |
 | ------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
+| country                   | `CountryIso2`   | Forced country to validate.                                                                                                                            | `undefined`                 |
 | defaultMaskMinPhoneLength | `number`        | Required phone length for countries without specified mask. Validation will fail if number of digits in phone value will be less that provided number. | `10`                        |
 | defaultMask               | `string`        | Mask for countries without specified mask.                                                                                                             | `"............"` (12 chars) |
 | countries                 | `CountryData[]` | An array of available countries.                                                                                                                       | `defaultCountries`          |
@@ -35,12 +36,13 @@ Validation behavior on countries with default masks can be slightly adjusted wit
 
 ## Returned values
 
-| Prop          | Type                                  | Description                               |
-| ------------- | ------------------------------------- | ----------------------------------------- |
-| isValid       | `boolean`                             | Is phone valid.                           |
-| country       | <code>CountryData \| undefined</code> | Parsed country from provided phone value. |
-| lengthMatch   | `boolean`                             | Is phone length match required value.     |
-| areaCodeMatch | `boolean`                             | Is country area code exists.              |
+| Prop          | Type                                  | Description                                |
+| ------------- | ------------------------------------- | ------------------------------------------ |
+| isValid       | `boolean`                             | Is phone valid.                            |
+| country       | <code>CountryData \| undefined</code> | Parsed country from provided phone value.  |
+| lengthMatch   | `boolean`                             | Is phone length match required value.      |
+| areaCodeMatch | `boolean`                             | Is country area code exists.               |
+| dialCodeMatch | `boolean`                             | Is country dial code match parsed country. |
 
 :::caution
 `isValid` does not guarantee that the entered phone number is 100% valid.

--- a/packages/docs/docs/02-Usage/03-PhoneValidation.md
+++ b/packages/docs/docs/02-Usage/03-PhoneValidation.md
@@ -43,13 +43,66 @@ Validation behavior on countries with default masks can be slightly adjusted wit
 | lengthMatch   | `boolean`                             | Is phone length match required value.      |
 | areaCodeMatch | `boolean`                             | Is country area code exists.               |
 | dialCodeMatch | `boolean`                             | Is country dial code match parsed country. |
+| formatMatch   | `boolean`                             | Is formatting applied correctly.           |
 
-:::caution
-`isValid` does not guarantee that the entered phone number is 100% valid.
-When `isValid` value becomes **true** it shows that the country was parsed from the provided phone value and that country's format mask was applied correctly.
+:::note
+`isValid` is not depend on `dialCodeMatch` and `formatMatch`.
+If you want to check dial codes and the formatting strictly you can add an additional check:
+
+```ts
+const phoneValidation = usePhoneValidation('+1 (123) 456-7890');
+const isPhoneValid =
+  phoneValidation.isValid &&
+  phoneValidation.dialCodeMatch &&
+  phoneValidation.formatMatch;
+```
+
 :::
 
-### Basic Usage
+:::caution
+`isValid` does **not guarantee** that the entered phone number **is 100% valid**.<br/>
+
+When `isValid` value becomes **true** it shows that the country was parsed from the provided phone value and has required amount of digits.
+:::
+
+### Dial codes overlap issue
+
+:::danger
+**Country value can be parsed incorrectly sometimes** <br/>
+It can happen when the country of provided phone value shares the same dial code with another country, but have a lower priory. For example, if user selects a _Vatican City_ and types a phone number like `+39 99 9999 9999` it will be validated as _Italy_ by default.
+:::
+
+This issue can happen with following countries:
+
+- `+1` United States, Canada, Dominican Republic, Puerto Rico
+- `+559` Curaçao, Caribbean Netherlands
+- `+39` Italy, Vatican City,
+- `+7` Kazakhstan, Russia
+
+To prevent this issue you can save the selected country value to the local state and pass it to the **country** validation property:
+
+```tsx
+const [phone, setPhone] = useState('');
+// highlight-start
+const [currentCountry, setCurrentCountry] = useState<CountryIso2>('ua');
+const validation = usePhoneValidation(phone, { country: currentCountry });
+// highlight-end
+
+return (
+  <PhoneInput
+    defaultCountry="ua"
+    value={phone}
+    onChange={(phone, country) => {
+      setPhone(phone);
+      // highlight-start
+      setCurrentCountry(country);
+      // highlight-end
+    }}
+  />
+);
+```
+
+## Basic Usage
 
 ```tsx
 import { useState } from 'react';
@@ -116,15 +169,3 @@ Output:
 <div style={{ margin: "8px 0 24px" }}>
 <Example />
 </div>
-
-:::tip
-Sometimes, when you don't want to check area codes (for example, you're not sure that the array of area codes covers all possible values), you can use `lengthMatch` to check the validation:
-
-```tsx
-const phoneValidation = usePhoneValidation('+1 (123) 456-7890');
-// highlight-start
-const isPhoneValid = phoneValidation.lengthMatch;
-// highlight-end
-```
-
-:::

--- a/packages/docs/docs/02-Usage/03-PhoneValidation.md
+++ b/packages/docs/docs/02-Usage/03-PhoneValidation.md
@@ -46,14 +46,14 @@ Validation behavior on countries with default masks can be slightly adjusted wit
 | formatMatch   | `boolean`                             | Is formatting applied correctly.           |
 
 :::note
-`isValid` is not depend on `dialCodeMatch` and `formatMatch`.
+`isValid` is not depend on `areaCodeMatch` and `formatMatch`.
 If you want to check dial codes and the formatting strictly you can add an additional check:
 
 ```ts
 const phoneValidation = usePhoneValidation('+1 (123) 456-7890');
 const isPhoneValid =
   phoneValidation.isValid &&
-  phoneValidation.dialCodeMatch &&
+  phoneValidation.areaCodeMatch &&
   phoneValidation.formatMatch;
 ```
 

--- a/packages/docs/docs/05-Migrations/01-migrate-to-v2.md
+++ b/packages/docs/docs/05-Migrations/01-migrate-to-v2.md
@@ -7,8 +7,6 @@ New features and bug fixes will be pushed only to v2.
 
 :::
 
-This document describes all breaking changes and provides a migration guide from version 1 to version 2.
-
 ## `initialCountry` has been renamed to `defaultCountry`
 
 You should rename `initialCountry` prop to `defaultCountry` in your codebase:

--- a/packages/docs/docs/05-Migrations/02-migrate-to-v2.2.md
+++ b/packages/docs/docs/05-Migrations/02-migrate-to-v2.2.md
@@ -1,0 +1,16 @@
+# Migrating from v2.1 to v2.2
+
+Validation logic has been changed since v2.2.
+`areaCodeMatch` and `formatMatch` have now become additional return properties and are not required to mark the phone as valid.
+
+You can additionally check `areaCodeMatch` and `formatMatch` to revert validation logic to how it was working before v2.2 release:
+
+```ts
+const phoneValidation = usePhoneValidation('+1 (123) 456-7890');
+const isPhoneValid =
+  phoneValidation.isValid &&
+  phoneValidation.areaCodeMatch &&
+  phoneValidation.formatMatch;
+```
+
+Check the [Phone Validation page](/docs/Usage/PhoneValidation) to get more info about new validation behavior.

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -94,8 +94,8 @@ const config = {
                 to: '/docs/Advanced%20Usage/usePhoneInput',
               },
               {
-                label: 'Migration',
-                to: '/docs/migration',
+                label: 'Migrations',
+                to: '/docs/Migrations/migrate-to-v2',
               },
             ],
           },

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -5,6 +5,7 @@ import React, { useMemo } from 'react';
 import { defaultCountries } from '../../data/countryData';
 import { usePhoneInput, UsePhoneInputConfig } from '../../hooks/usePhoneInput';
 import { buildClassNames } from '../../style/buildClassNames';
+import { CountryIso2 } from '../../types';
 import { getCountry } from '../../utils';
 import {
   CountrySelector,
@@ -64,10 +65,10 @@ export interface PhoneInputProps
 
   /**
    * @description Callback that calls on phone change
-   * @params *phone* - new phone value
+   * @params `phone` - new phone value, `country` - country iso2 value
    * @default undefined
    */
-  onChange?: (phone: string) => void;
+  onChange?: (phone: string, country: CountryIso2) => void;
 }
 
 export const PhoneInput: React.FC<PhoneInputProps> = ({
@@ -95,7 +96,7 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
       countries,
       ...usePhoneInputConfig,
       onChange: (data) => {
-        onChange?.(data.phone);
+        onChange?.(data.phone, data.country);
       },
     });
 

--- a/src/stories/Validation.stories.tsx
+++ b/src/stories/Validation.stories.tsx
@@ -3,7 +3,12 @@ import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import * as Yup from 'yup';
 
-import { PhoneInput, usePhoneValidation, validatePhone } from '../index';
+import {
+  CountryIso2,
+  PhoneInput,
+  usePhoneValidation,
+  validatePhone,
+} from '../index';
 
 const ValidationProperty: React.FC<{
   title: string;
@@ -20,20 +25,28 @@ const ValidationProperty: React.FC<{
 
 export const Default = () => {
   const [phone, setPhone] = useState('');
-  const validation = usePhoneValidation(phone);
+  const [phoneCountry, setPhoneCountry] = useState<CountryIso2>('ua');
+  const validation = usePhoneValidation(phone, { country: phoneCountry });
 
   return (
     <div>
       <PhoneInput
         defaultCountry="ua"
         value={phone}
-        onChange={(phone) => setPhone(phone)}
+        onChange={(phone, country) => {
+          setPhone(phone);
+          setPhoneCountry(country);
+        }}
       />
       <ValidationProperty title="isValid" value={validation.isValid} />
       <ValidationProperty title="lengthMatch" value={validation.lengthMatch} />
       <ValidationProperty
         title="areaCodeMatch"
         value={validation.areaCodeMatch}
+      />
+      <ValidationProperty
+        title="dialCodeMatch"
+        value={validation.dialCodeMatch}
       />
       <ValidationProperty title="country" value={validation.country?.iso2} />
     </div>

--- a/src/stories/Validation.stories.tsx
+++ b/src/stories/Validation.stories.tsx
@@ -52,6 +52,37 @@ export const Default = () => {
   );
 };
 
+export const ValidationWithCountrySaving = () => {
+  const [phone, setPhone] = useState('');
+  const [currentCountry, setCurrentCountry] = useState<CountryIso2>('ua');
+  const validation = usePhoneValidation(phone, { country: currentCountry });
+
+  return (
+    <div>
+      <PhoneInput
+        defaultCountry="ua"
+        value={phone}
+        onChange={(phone, country) => {
+          setPhone(phone);
+          setCurrentCountry(country);
+        }}
+      />
+      <ValidationProperty title="isValid" value={validation.isValid} />
+      <ValidationProperty title="formatMatch" value={validation.formatMatch} />
+      <ValidationProperty title="lengthMatch" value={validation.lengthMatch} />
+      <ValidationProperty
+        title="areaCodeMatch"
+        value={validation.areaCodeMatch}
+      />
+      <ValidationProperty
+        title="dialCodeMatch"
+        value={validation.dialCodeMatch}
+      />
+      <ValidationProperty title="country" value={validation.country?.iso2} />
+    </div>
+  );
+};
+
 export const ReactHookForm = () => {
   const {
     control,

--- a/src/stories/Validation.stories.tsx
+++ b/src/stories/Validation.stories.tsx
@@ -23,6 +23,27 @@ const ValidationProperty: React.FC<{
   );
 };
 
+const ValidationInfo: React.FC<{
+  validation: ReturnType<typeof usePhoneValidation>;
+}> = ({ validation }) => {
+  return (
+    <>
+      <ValidationProperty title="isValid" value={validation.isValid} />
+      <ValidationProperty title="formatMatch" value={validation.formatMatch} />
+      <ValidationProperty title="lengthMatch" value={validation.lengthMatch} />
+      <ValidationProperty
+        title="areaCodeMatch"
+        value={validation.areaCodeMatch}
+      />
+      <ValidationProperty
+        title="dialCodeMatch"
+        value={validation.dialCodeMatch}
+      />
+      <ValidationProperty title="country" value={validation.country?.iso2} />
+    </>
+  );
+};
+
 export const Default = () => {
   const [phone, setPhone] = useState('');
   const validation = usePhoneValidation(phone);
@@ -36,18 +57,7 @@ export const Default = () => {
           setPhone(phone);
         }}
       />
-      <ValidationProperty title="isValid" value={validation.isValid} />
-      <ValidationProperty title="formatMatch" value={validation.formatMatch} />
-      <ValidationProperty title="lengthMatch" value={validation.lengthMatch} />
-      <ValidationProperty
-        title="areaCodeMatch"
-        value={validation.areaCodeMatch}
-      />
-      <ValidationProperty
-        title="dialCodeMatch"
-        value={validation.dialCodeMatch}
-      />
-      <ValidationProperty title="country" value={validation.country?.iso2} />
+      <ValidationInfo validation={validation} />
     </div>
   );
 };
@@ -67,18 +77,7 @@ export const ValidationWithCountrySaving = () => {
           setCurrentCountry(country);
         }}
       />
-      <ValidationProperty title="isValid" value={validation.isValid} />
-      <ValidationProperty title="formatMatch" value={validation.formatMatch} />
-      <ValidationProperty title="lengthMatch" value={validation.lengthMatch} />
-      <ValidationProperty
-        title="areaCodeMatch"
-        value={validation.areaCodeMatch}
-      />
-      <ValidationProperty
-        title="dialCodeMatch"
-        value={validation.dialCodeMatch}
-      />
-      <ValidationProperty title="country" value={validation.country?.iso2} />
+      <ValidationInfo validation={validation} />
     </div>
   );
 };
@@ -137,16 +136,7 @@ export const Formik = () => {
 
       const validationResult = validatePhone(phone);
       if (!validationResult.isValid) {
-        errors.phone = 'something went wrong';
-      }
-      if (!validationResult.lengthMatch) {
-        errors.phone = 'wrong phone length';
-      }
-      if (validationResult.areaCodeMatch === false) {
-        errors.phone = 'wrong area code';
-      }
-      if (!validationResult.country) {
-        errors.phone = 'wrong dial code';
+        errors.phone = 'Phone is not valid';
       }
 
       return errors;
@@ -166,9 +156,7 @@ export const Formik = () => {
           name: 'phone',
         }}
       />
-      <code style={{ color: errors.phone ? 'red' : 'green' }}>
-        <p>{errors.phone ? `Error: ${errors.phone}` : 'Phone is valid'}</p>
-      </code>
+      <ValidationProperty title="isValid" value={!errors.phone} />
     </div>
   );
 };
@@ -207,9 +195,7 @@ export const FormikWithYup = () => {
           name: 'phone',
         }}
       />
-      <code style={{ color: errors.phone ? 'red' : 'green' }}>
-        <p>{errors.phone ? `Error: ${errors.phone}` : 'Phone is valid'}</p>
-      </code>
+      <ValidationProperty title="isValid" value={!errors.phone} />
     </div>
   );
 };

--- a/src/stories/Validation.stories.tsx
+++ b/src/stories/Validation.stories.tsx
@@ -25,20 +25,19 @@ const ValidationProperty: React.FC<{
 
 export const Default = () => {
   const [phone, setPhone] = useState('');
-  const [phoneCountry, setPhoneCountry] = useState<CountryIso2>('ua');
-  const validation = usePhoneValidation(phone, { country: phoneCountry });
+  const validation = usePhoneValidation(phone);
 
   return (
     <div>
       <PhoneInput
         defaultCountry="ua"
         value={phone}
-        onChange={(phone, country) => {
+        onChange={(phone) => {
           setPhone(phone);
-          setPhoneCountry(country);
         }}
       />
       <ValidationProperty title="isValid" value={validation.isValid} />
+      <ValidationProperty title="formatMatch" value={validation.formatMatch} />
       <ValidationProperty title="lengthMatch" value={validation.lengthMatch} />
       <ValidationProperty
         title="areaCodeMatch"

--- a/src/stories/Validation.stories.tsx
+++ b/src/stories/Validation.stories.tsx
@@ -82,6 +82,40 @@ export const ValidationWithCountrySaving = () => {
   );
 };
 
+export const ValidationWithDisabledCountryGuessing = () => {
+  const [phone, setPhone] = useState('');
+  const [shouldSaveCountry, setShouldSaveCountry] = useState(false);
+  const [currentCountry, setCurrentCountry] = useState<CountryIso2>('ua');
+  const validation = usePhoneValidation(phone, {
+    country: shouldSaveCountry ? currentCountry : undefined,
+  });
+
+  return (
+    <div>
+      <input
+        type="checkbox"
+        id="check"
+        checked={shouldSaveCountry}
+        onChange={(e) => setShouldSaveCountry(e.target.checked)}
+        style={{ marginBottom: '10px' }}
+      />
+      <label htmlFor="check" style={{ color: 'black' }}>
+        Pass selected country to validation
+      </label>
+      <PhoneInput
+        disableCountryGuess
+        defaultCountry="ua"
+        value={phone}
+        onChange={(phone, country) => {
+          setPhone(phone);
+          setCurrentCountry(country);
+        }}
+      />
+      <ValidationInfo validation={validation} />
+    </div>
+  );
+};
+
 export const ReactHookForm = () => {
   const {
     control,

--- a/src/utils/countryUtils/__tests__/guessCountryByPartialNumber.test.ts
+++ b/src/utils/countryUtils/__tests__/guessCountryByPartialNumber.test.ts
@@ -211,7 +211,7 @@ describe('guessCountryByPartialNumber', () => {
       }),
     ).toMatchObject({
       country: { dialCode: '1', iso2: 'do' },
-      areaCodeMatch: false,
+      areaCodeMatch: undefined,
     });
 
     expect(

--- a/src/utils/countryUtils/guessCountryByPartialNumber.ts
+++ b/src/utils/countryUtils/guessCountryByPartialNumber.ts
@@ -127,7 +127,11 @@ export const guessCountryByPartialNumber = ({
       !result.areaCodeMatch;
 
     if (shouldSaveDialCode) {
-      result.country = currentCountry;
+      result = {
+        country: currentCountry,
+        areaCodeMatch: currentCountry?.areaCodes ? false : undefined,
+        fullDialCodeMatch: true,
+      };
     }
   }
 

--- a/src/utils/phoneUtils/__tests__/validatePhone.test.ts
+++ b/src/utils/phoneUtils/__tests__/validatePhone.test.ts
@@ -263,4 +263,115 @@ describe('validatePhone', () => {
       isValid: false,
     });
   });
+
+  describe('should support config.country', () => {
+    test('should work with matched dial code', () => {
+      expect(validatePhone('+1 999999999999', { country: 'do' })).toMatchObject(
+        {
+          country: getCountry('do'),
+          areaCodeMatch: undefined,
+          lengthMatch: true,
+          isValid: true,
+        },
+      );
+
+      expect(validatePhone('+1', { country: 'pr' })).toMatchObject({
+        country: getCountry('pr'),
+        areaCodeMatch: undefined,
+        lengthMatch: false,
+        isValid: false,
+      });
+
+      expect(
+        validatePhone('+1 (999) 999-9999', { country: 'us' }),
+      ).toMatchObject({
+        country: getCountry('us'),
+        areaCodeMatch: false,
+        lengthMatch: true,
+        isValid: false,
+      });
+
+      expect(
+        validatePhone('+1 (999) 999-9999', { country: 'ca' }),
+      ).toMatchObject({
+        country: getCountry('ca'),
+        areaCodeMatch: false,
+        lengthMatch: true,
+        isValid: false,
+      });
+    });
+
+    test('should use country from config.country for validation', () => {
+      expect(
+        validatePhone('+1 (201) 567-8900', { country: 'ua' }),
+      ).toMatchObject({
+        country: getCountry('ua'),
+        areaCodeMatch: undefined,
+        lengthMatch: false,
+        isValid: false,
+      });
+
+      expect(
+        validatePhone('+380 (99) 999 99 99', { country: 'us' }),
+      ).toMatchObject({
+        country: getCountry('us'),
+        areaCodeMatch: false,
+        lengthMatch: false,
+        isValid: false,
+      });
+
+      expect(
+        validatePhone('+1 (204) 567-8900', { country: 'us' }),
+      ).toMatchObject({
+        country: getCountry('us'),
+        areaCodeMatch: false,
+        lengthMatch: true,
+        isValid: false,
+      });
+    });
+  });
+
+  describe('should return dialCodeMatch', () => {
+    test('should return true for valid phone', () => {
+      expect(validatePhone('+1 (204) 567-8900')).toMatchObject({
+        country: getCountry('ca'),
+        dialCodeMatch: true,
+        areaCodeMatch: true,
+        lengthMatch: true,
+        isValid: true,
+      });
+    });
+
+    test('should return false for invalid phone', () => {
+      expect(validatePhone('+99999999')).toMatchObject({
+        country: undefined,
+        dialCodeMatch: false,
+        areaCodeMatch: undefined,
+        lengthMatch: false,
+        isValid: false,
+      });
+    });
+
+    test('should work with config.country', () => {
+      expect(
+        validatePhone('+1 (201) 567-8900', { country: 'ua' }),
+      ).toMatchObject({
+        country: getCountry('ua'),
+        dialCodeMatch: false,
+        areaCodeMatch: undefined,
+        lengthMatch: false,
+        isValid: false,
+      });
+
+      expect(
+        validatePhone('+1 (201) 567-8900', { country: 'us' }),
+      ).toMatchObject({
+        country: getCountry('us'),
+        dialCodeMatch: true,
+        areaCodeMatch: true,
+        lengthMatch: true,
+        isValid: true,
+      });
+    });
+  });
 });

--- a/src/utils/phoneUtils/__tests__/validatePhone.test.ts
+++ b/src/utils/phoneUtils/__tests__/validatePhone.test.ts
@@ -30,7 +30,7 @@ describe('validatePhone', () => {
     });
   });
 
-  test('should handle phone value fill', () => {
+  test('should handle phone length match', () => {
     expect(validatePhone('+1 (999) 999-9999')).toMatchObject({
       lengthMatch: true,
     });
@@ -51,8 +51,9 @@ describe('validatePhone', () => {
       lengthMatch: false,
     });
 
+    // allow phone number overflow
     expect(validatePhone('+1 (999) 999-99999')).toMatchObject({
-      lengthMatch: false,
+      lengthMatch: true,
     });
   });
 
@@ -95,32 +96,82 @@ describe('validatePhone', () => {
     });
   });
 
+  test('should handle formatting match', () => {
+    expect(validatePhone('+1 (999) 999-9999')).toMatchObject({
+      formatMatch: true,
+    });
+
+    expect(validatePhone('')).toMatchObject({
+      formatMatch: false,
+    });
+
+    expect(validatePhone('+')).toMatchObject({
+      formatMatch: false,
+    });
+
+    expect(validatePhone('+380')).toMatchObject({
+      formatMatch: false,
+    });
+
+    expect(validatePhone('+1 (999) 999-')).toMatchObject({
+      formatMatch: false,
+    });
+
+    expect(validatePhone('19999999999')).toMatchObject({
+      formatMatch: false,
+    });
+
+    expect(validatePhone('+19999999999')).toMatchObject({
+      formatMatch: false,
+    });
+
+    expect(validatePhone('+1 (999) 999-999')).toMatchObject({
+      formatMatch: false,
+    });
+
+    expect(validatePhone('1 (999) 999-999')).toMatchObject({
+      formatMatch: false,
+    });
+
+    expect(validatePhone('+1 (999) 999-99999')).toMatchObject({
+      formatMatch: true,
+    });
+  });
+
   test('should return isValid', () => {
     expect(validatePhone('+1 (201) 234-5678')).toMatchObject({
       isValid: true,
     });
 
     expect(validatePhone('1 (201) 234-5678')).toMatchObject({
-      isValid: false,
+      isValid: true,
     });
 
     expect(validatePhone('+12012345678')).toMatchObject({
-      isValid: false,
+      isValid: true,
     });
 
     expect(validatePhone('+1 201 234 5678')).toMatchObject({
-      isValid: false,
+      isValid: true,
+    });
+
+    expect(validatePhone('+1 (402) 999-9999-')).toMatchObject({
+      isValid: true,
+    });
+
+    expect(validatePhone('+1 (402) 999-99999')).toMatchObject({
+      isValid: true,
     });
 
     expect(validatePhone('+1 (402) 999-999')).toMatchObject({
       isValid: false,
     });
 
-    expect(validatePhone('+1 (402) 999-9999-')).toMatchObject({
+    expect(validatePhone('')).toMatchObject({
       isValid: false,
     });
 
-    expect(validatePhone('+1 (402) 999-99999')).toMatchObject({
+    expect(validatePhone('+1 ')).toMatchObject({
       isValid: false,
     });
   });
@@ -167,7 +218,7 @@ describe('validatePhone', () => {
       country: getCountry('ca'),
       areaCodeMatch: false,
       lengthMatch: true,
-      isValid: false,
+      isValid: true,
     });
   });
 
@@ -175,8 +226,9 @@ describe('validatePhone', () => {
     expect(validatePhone('+1 (201) 234-5678', { prefix: '' })).toMatchObject({
       country: getCountry('us'),
       areaCodeMatch: true,
-      lengthMatch: false,
-      isValid: false,
+      lengthMatch: true,
+      isValid: true,
+      formatMatch: false,
     });
 
     expect(validatePhone('1 (201) 234-5678', { prefix: '' })).toMatchObject({
@@ -184,6 +236,7 @@ describe('validatePhone', () => {
       areaCodeMatch: true,
       lengthMatch: true,
       isValid: true,
+      formatMatch: true,
     });
 
     expect(validatePhone('-1 (201) 234-5678', { prefix: '-' })).toMatchObject({
@@ -191,6 +244,7 @@ describe('validatePhone', () => {
       areaCodeMatch: true,
       lengthMatch: true,
       isValid: true,
+      formatMatch: true,
     });
   });
 
@@ -200,8 +254,9 @@ describe('validatePhone', () => {
     ).toMatchObject({
       country: getCountry('us'),
       areaCodeMatch: true,
-      lengthMatch: false,
-      isValid: false,
+      lengthMatch: true,
+      isValid: true,
+      formatMatch: false,
     });
 
     expect(
@@ -211,6 +266,7 @@ describe('validatePhone', () => {
       areaCodeMatch: true,
       lengthMatch: true,
       isValid: true,
+      formatMatch: true,
     });
   });
 
@@ -224,42 +280,46 @@ describe('validatePhone', () => {
       country: getCountry('lt'),
       areaCodeMatch: undefined,
       lengthMatch: true,
+      formatMatch: true,
       isValid: true,
     });
 
     expect(
       validatePhone('+370 123456789000', {
-        defaultMask: '.... .....',
+        defaultMask: '.... .... ....',
         defaultMaskMinPhoneLength: 11,
       }),
     ).toMatchObject({
       country: getCountry('lt'),
       areaCodeMatch: undefined,
-      lengthMatch: false,
-      isValid: false,
+      lengthMatch: true,
+      formatMatch: false,
+      isValid: true,
     });
 
     expect(
-      validatePhone('+370 1234 567890', {
-        defaultMask: '.... .....',
+      validatePhone('+370 1234 5678 90', {
+        defaultMask: '.... .... ....',
         defaultMaskMinPhoneLength: 11,
       }),
     ).toMatchObject({
       country: getCountry('lt'),
       areaCodeMatch: undefined,
-      lengthMatch: false,
-      isValid: false,
+      lengthMatch: true,
+      formatMatch: true,
+      isValid: true,
     });
 
     expect(
       validatePhone('+370 1234 567', {
-        defaultMask: '.... .....',
+        defaultMask: '.... .... ....',
         defaultMaskMinPhoneLength: 11,
       }),
     ).toMatchObject({
       country: getCountry('lt'),
       areaCodeMatch: undefined,
       lengthMatch: false,
+      formatMatch: true,
       isValid: false,
     });
   });
@@ -288,7 +348,7 @@ describe('validatePhone', () => {
         country: getCountry('us'),
         areaCodeMatch: false,
         lengthMatch: true,
-        isValid: false,
+        isValid: true,
       });
 
       expect(
@@ -297,7 +357,17 @@ describe('validatePhone', () => {
         country: getCountry('ca'),
         areaCodeMatch: false,
         lengthMatch: true,
-        isValid: false,
+        isValid: true,
+      });
+
+      expect(
+        validatePhone('+380 (99) 999 99 99', { country: 'ua' }),
+      ).toMatchObject({
+        country: getCountry('ua'),
+        areaCodeMatch: undefined,
+        lengthMatch: true,
+        formatMatch: true,
+        isValid: true,
       });
     });
 
@@ -316,7 +386,7 @@ describe('validatePhone', () => {
       ).toMatchObject({
         country: getCountry('us'),
         areaCodeMatch: false,
-        lengthMatch: false,
+        lengthMatch: true,
         isValid: false,
       });
 
@@ -326,7 +396,7 @@ describe('validatePhone', () => {
         country: getCountry('us'),
         areaCodeMatch: false,
         lengthMatch: true,
-        isValid: false,
+        isValid: true,
       });
     });
   });
@@ -373,5 +443,23 @@ describe('validatePhone', () => {
         isValid: true,
       });
     });
+  });
+
+  test('should work with all default countries', () => {
+    for (const c of defaultCountries) {
+      const country = parseCountry(c);
+
+      const phone = `+${country.dialCode} ${
+        country.format?.replace(/\./g, '9') || '9999999999'
+      }`;
+
+      const validationResult = validatePhone(phone);
+
+      expect(validationResult).toMatchObject({
+        dialCodeMatch: true,
+        lengthMatch: true,
+        isValid: true,
+      });
+    }
   });
 });

--- a/src/utils/phoneUtils/validatePhone.ts
+++ b/src/utils/phoneUtils/validatePhone.ts
@@ -88,9 +88,10 @@ export const validatePhone = (
     };
   }
 
-  const isDefaultMask = !country.format;
   const countryMask = country.format || defaultMask;
+  const isDefaultMask = !country.format;
 
+  // mask length (only digits)
   const requiredMaskLength = isDefaultMask
     ? defaultMaskMinPhoneLength - country.dialCode.length
     : countryMask.length - countryMask.replaceAll(MASK_CHAR, '').length;


### PR DESCRIPTION
## What has been done

- Updated validation logic (fix for #46)
  - Now phone should start with a dial code and have no less that the required number of digits to be marked as "valid"
  - Added the `formatMatch` and `dialCodeMatch` return values
  - Added the `country` prop to the validation function
- Added `country` value to `onChange` callback 
