### PR TITLE
Set country to "us" if provided default country is invalid 

### DIFF
--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { defaultCountries } from '../../data/countryData';
+import { CountryIso2 } from '../../types';
 import { parseCountry, removeNonDigits } from '../../utils';
 import { buildCountryData } from '../../utils/countryUtils/buildCountryData';
 import {
@@ -327,6 +328,25 @@ describe('PhoneInput', () => {
       render(<PhoneInput />);
       expect(getCountrySelector()).toHaveAttribute('data-country', 'us');
       expect(getInput().value).toBe('+1 ');
+    });
+
+    test('should set "us" if provided invalid default country', () => {
+      const logSpy = jest
+        .spyOn(global.console, 'error')
+        .mockImplementation(() => null);
+
+      render(<PhoneInput defaultCountry={'test' as CountryIso2} />);
+
+      expect(getCountrySelector()).toHaveAttribute('data-country', 'us');
+      expect(getInput().value).toBe('+1 ');
+
+      expect(logSpy).toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(
+        '[react-international-phone]: can not find a country with "test" iso2 code',
+      );
+
+      logSpy.mockRestore();
     });
   });
 

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -13,6 +13,7 @@ import {
   getCountry,
   getCursorPosition,
   guessCountryByPartialNumber,
+  parseCountry,
   removeNonDigits,
 } from '../utils';
 import { useHistoryState } from './useHistoryState';
@@ -217,19 +218,25 @@ export const usePhoneInput = ({
         currentCountryIso2: defaultCountry,
       });
 
-      const defaultCountryFull = (countryGuessResult.country ||
+      const guessedCountryFull = (countryGuessResult.country ||
         getCountry({
           value: defaultCountry,
           field: 'iso2',
           countries,
         })) as ParsedCountry;
 
-      if (!defaultCountryFull) {
+      if (!guessedCountryFull) {
         // default country is not passed, or iso code do not match
         console.error(
-          `[react-international-phone]: can not find a country with "${country}" iso2 code`,
+          `[react-international-phone]: can not find a country with "${defaultCountry}" iso2 code`,
         );
       }
+
+      const defaultCountryFull =
+        guessedCountryFull || // set "us" if user provided not valid country
+        parseCountry(
+          countries.find((c) => parseCountry(c).iso2 === 'us') as CountryData,
+        );
 
       const phone = formatPhoneValue({
         value,

--- a/src/stories/Dev.stories.tsx
+++ b/src/stories/Dev.stories.tsx
@@ -5,7 +5,6 @@ import { CountrySelectorStyleProps } from '../components/CountrySelector/Country
 import { PhoneInput } from '../components/PhoneInput/PhoneInput';
 import { defaultCountries } from '../data/countryData';
 import { usePhoneValidation } from '../hooks/usePhoneValidation';
-import { CountryIso2 } from '../types';
 import { parseCountry } from '../utils';
 import { MuiPhone } from './UiLibsExample/components/MuiPhone';
 
@@ -147,7 +146,7 @@ export const WrongDefaultCountryCode = () => {
     <PhoneInput
       value={phone}
       onChange={setPhone}
-      defaultCountry={'not-valid-code' as CountryIso2}
+      defaultCountry="not-valid-code"
     />
   );
 };

--- a/src/stories/Dev.stories.tsx
+++ b/src/stories/Dev.stories.tsx
@@ -5,6 +5,7 @@ import { CountrySelectorStyleProps } from '../components/CountrySelector/Country
 import { PhoneInput } from '../components/PhoneInput/PhoneInput';
 import { defaultCountries } from '../data/countryData';
 import { usePhoneValidation } from '../hooks/usePhoneValidation';
+import { CountryIso2 } from '../types';
 import { parseCountry } from '../utils';
 import { MuiPhone } from './UiLibsExample/components/MuiPhone';
 
@@ -136,5 +137,17 @@ export const TwoInputsTest = () => {
         inputProps={{ id: 'bottom' }}
       />
     </div>
+  );
+};
+
+export const WrongDefaultCountryCode = () => {
+  const [phone, setPhone] = useState('');
+
+  return (
+    <PhoneInput
+      value={phone}
+      onChange={setPhone}
+      defaultCountry={'not-valid-code' as CountryIso2}
+    />
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ type SubRegion =
   | 'north-africa';
 
 export type CountryIso2 =
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | (string & {}) // allow any string but add autocompletion for values below
   | 'af'
   | 'al'
   | 'dz'


### PR DESCRIPTION
## What has been done
- Handled invalid `defaultCountry` values
- Fixed related console error
- Updated type for `CountryIso2` to string (with auto-completion)

