### PR TITLE
fix(data): Update Ivory Coast Phone Number Format to Support 10 Digit…

### DIFF
--- a/src/data/countryData.ts
+++ b/src/data/countryData.ts
@@ -150,7 +150,7 @@ export const defaultCountries: CountryData[] = [
   ['Congo', ['africa'], 'cd', '243'],
   ['Congo', ['africa'], 'cg', '242'],
   ['Costa Rica', ['america', 'central-america'], 'cr', '506', '....-....'],
-  ["Côte d'Ivoire", ['africa'], 'ci', '225', '.. .. .. ..'],
+  ["Côte d'Ivoire", ['africa'], 'ci', '225', '.. .. .. .. ..'],
   ['Croatia', ['europe', 'eu-union', 'ex-yugos'], 'hr', '385'],
   ['Cuba', ['america', 'carribean'], 'cu', '53'],
   ['Curaçao', ['america', 'carribean'], 'cw', '599', '', 0],


### PR DESCRIPTION
The current phone number format for Ivory Coast needs to be updated. The latest phone number format should be "(+225) 07 79 59 29 93," with 10 digits following the area code. However, the existing component only supports entering 8 digits after the area code.

Reference Link: https://en.wikipedia.org/wiki/Telephone_numbers_in_Ivory_Coast