### PR TITLE
fix(CountrySelectorDropdown): prevent form submit on select country

### DIFF
--- a/src/components/CountrySelector/CountrySelectorDropdown.tsx
+++ b/src/components/CountrySelector/CountrySelectorDropdown.tsx
@@ -125,6 +125,7 @@ export const CountrySelectorDropdown: React.FC<
     e.stopPropagation();
 
     if (e.key === 'Enter') {
+      e.preventDefault();
       const focusedCountry = parseCountry(countries[focusedItemIndex]);
       handleCountrySelect(focusedCountry);
       return;


### PR DESCRIPTION
## What has been done
Fix https://github.com/goveo/react-international-phone/issues/81 by preventing the default behavior when pressing `Enter` inside `CountrySelectorDropdown`
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Tests for the changes have been added (for bug fixes/features).
- [x] Docs have been added / updated (for bug fixes / features).

## Screenshots (if appropriate):
Before:

https://github.com/goveo/react-international-phone/assets/6539258/7b331f47-8109-4eeb-921a-27f19a2372e8

After:

https://github.com/goveo/react-international-phone/assets/6539258/9956b7a9-e843-472f-a97b-3c9ecea28d72
