### PR TITLE
Fix initial country guess when `disableDialCodeAndPrefix` is true

### DIFF
--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -212,18 +212,21 @@ export const usePhoneInput = ({
 
   const [{ phone, country }, updateHistory, undo, redo] = useHistoryState(
     () => {
-      const countryGuessResult = guessCountryByPartialNumber({
-        phone: value,
-        countries,
-        currentCountryIso2: defaultCountry,
-      });
+      const countryGuessResult = disableDialCodeAndPrefix
+        ? null
+        : guessCountryByPartialNumber({
+            phone: value,
+            countries,
+            currentCountryIso2: defaultCountry,
+          });
 
-      const guessedCountryFull = (countryGuessResult.country ||
+      const guessedCountryFull =
+        countryGuessResult?.country ||
         getCountry({
           value: defaultCountry,
           field: 'iso2',
           countries,
-        })) as ParsedCountry;
+        });
 
       if (!guessedCountryFull) {
         // default country is not passed, or iso code do not match

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,10 @@ export { PhoneInput } from './components/PhoneInput/PhoneInput';
 export { defaultCountries } from './data/countryData';
 export { usePhoneInput } from './hooks/usePhoneInput';
 export type { CountryData, CountryIso2 } from './types';
-export { buildCountryData, parseCountry } from './utils';
+export {
+  buildCountryData,
+  getCountry,
+  guessCountryByPartialNumber as guessCountryByPartialPhoneNumber,
+  parseCountry,
+  removeDialCode,
+} from './utils';

--- a/src/stories/Dev.stories.tsx
+++ b/src/stories/Dev.stories.tsx
@@ -4,7 +4,12 @@ import React, { useState } from 'react';
 import { CountrySelectorStyleProps } from '../components/CountrySelector/CountrySelector';
 import { PhoneInput } from '../components/PhoneInput/PhoneInput';
 import { defaultCountries } from '../data/countryData';
-import { parseCountry } from '../utils';
+import {
+  getCountry,
+  guessCountryByPartialPhoneNumber,
+  parseCountry,
+  removeDialCode,
+} from '../index';
 import { MuiPhone } from './UiLibsExample/components/MuiPhone';
 
 export default {
@@ -139,5 +144,45 @@ export const WrongDefaultCountryCode = () => {
       onChange={setPhone}
       defaultCountry="not-valid-code"
     />
+  );
+};
+
+export const WithoutDialCode = () => {
+  const initialPhone = '+14045555555';
+
+  const [country, setCountry] = useState(() => {
+    // guessing country of inital phone
+    return guessCountryByPartialPhoneNumber({ phone: initialPhone }).country;
+  });
+
+  const [phone, setPhone] = useState(
+    // removing dial code for inital phone
+    // '+14045555555' -> '4045555555'
+    removeDialCode({
+      phone: initialPhone,
+      dialCode: country?.dialCode || '',
+    }),
+  );
+
+  // constructing E164 format from country and phone value
+  const e164Phone = country
+    ? `+${country.dialCode}${phone.replace(/\D/g, '')}`
+    : '';
+
+  return (
+    <div style={{ color: 'black', fontSize: '13px' }}>
+      <span>E164 phone: {e164Phone}</span>
+      <PhoneInput
+        value={phone}
+        onChange={(phone, country) => {
+          setPhone(phone);
+          // save country to get ability to construct E164
+          setCountry(getCountry({ field: 'iso2', value: country }));
+        }}
+        // passing country as "defaultCountry"
+        defaultCountry={country?.iso2}
+        disableDialCodeAndPrefix
+      />
+    </div>
   );
 };

--- a/src/utils/countryUtils/getCountry.ts
+++ b/src/utils/countryUtils/getCountry.ts
@@ -1,3 +1,4 @@
+import { defaultCountries } from '../../data/countryData';
 import { CountryData, ParsedCountry } from '../../types';
 import { parseCountry } from './parseCountry';
 
@@ -6,13 +7,19 @@ const constructFieldNotSupportedErrorMessage = (field: keyof ParsedCountry) => {
 };
 
 export const getCountry = ({
-  value,
   field,
-  countries,
+  value,
+  countries = defaultCountries,
 }: {
-  value: CountryData[number];
+  /**
+   * field to search by
+   */
   field: keyof ParsedCountry;
-  countries: CountryData[];
+  /**
+   * value to search for
+   */
+  value: CountryData[number];
+  countries?: CountryData[];
 }): ParsedCountry | undefined => {
   if (['priority'].includes(field)) {
     throw new Error(constructFieldNotSupportedErrorMessage(field));

--- a/src/utils/countryUtils/guessCountryByPartialNumber.ts
+++ b/src/utils/countryUtils/guessCountryByPartialNumber.ts
@@ -1,3 +1,4 @@
+import { defaultCountries } from '../../data/countryData';
 import {
   CountryData,
   CountryGuessResult,
@@ -10,11 +11,11 @@ import { parseCountry } from './parseCountry';
 
 export const guessCountryByPartialNumber = ({
   phone: partialPhone,
-  countries,
+  countries = defaultCountries,
   currentCountryIso2,
 }: {
   phone: string;
-  countries: CountryData[];
+  countries?: CountryData[];
   currentCountryIso2?: CountryIso2;
 }): CountryGuessResult => {
   const emptyResult = {


### PR DESCRIPTION
## What has been done
- removed initial country guess when `disableDialCodeAndPrefix` is set to `true`
- exported `getCountry`, `guessCountryByPartialPhoneNumber` and `removeDialCode` helper functions
- set default value for `countries` prop to `defaultCountries` in `guessCountryByPartialNumber` and `getCountry`