### PR TITLE
Rename return values

### DIFF
--- a/packages/docs/docs/02-Usage/01-PhoneInput.md
+++ b/packages/docs/docs/02-Usage/01-PhoneInput.md
@@ -41,7 +41,7 @@ defaultValue={'""'}
 ### `onChange`
 
 <PropDescription
-type="(phone: string, meta: { country: ParsedCountry, displayValue: string }) => void"
+type="(phone: string, meta: { country: ParsedCountry, inputValue: string }) => void"
 description="Callback that calls on phone change"
 defaultValue="undefined"
 />

--- a/packages/docs/docs/02-Usage/01-PhoneInput.md
+++ b/packages/docs/docs/02-Usage/01-PhoneInput.md
@@ -241,6 +241,13 @@ type="(iso2: CountryIso2) => void"
 description="Set some country value (works same as country selector country item click handler)"
 />
 
+#### `state`
+
+<PropDescription
+type="{ phone: string; inputValue: string; country: ParsedCountry }"
+description="State of the phone input"
+/>
+
 ## `ParsedCountry` type
 
 `onChange` callback provides `country` object with `ParsedCountry` type:

--- a/packages/docs/docs/02-Usage/02-ModifyCountries.md
+++ b/packages/docs/docs/02-Usage/02-ModifyCountries.md
@@ -62,7 +62,7 @@ Each country in `defaultCountries` follows this format:
   string, // country name
   CountryIso2, // iso2 code
   string, // international dial code
-  string | FormatConfig, // format (optional)
+  FormatConfig | string, // format (optional)
   number, // order priority (optional)
   string[], // area codes (optional)
 ]

--- a/packages/docs/docs/04-Advanced Usage/01-usePhoneInput.md
+++ b/packages/docs/docs/04-Advanced Usage/01-usePhoneInput.md
@@ -13,16 +13,16 @@ Use `phone` (as value), `handlePhoneValueChange` (as onChange callback) and `inp
 // import { usePhoneInput } from 'react-international-phone';
 
 const {
+  inputValue,
+  phone,
   country,
   setCountry,
-  phone,
-  e164Phone,
   handlePhoneValueChange,
   inputRef,
 } = usePhoneInput({
   defaultCountry: 'us',
   value: '+1 (234)',
-  onChange: ({ phone, e164Phone, country }) => {
+  onChange: ({ phone, inputValue, country }) => {
     // make something on change
   },
 });
@@ -41,7 +41,7 @@ defaultValue={'""'}
 ### `onChange`
 
 <PropDescription
-type="(data: { phone: string; e164Phone: string; country: ParsedCountry }) => void"
+type="(data: { phone: string; inputValue: string; country: ParsedCountry }) => void"
 description="Callback that calls on phone change"
 defaultValue="undefined"
 />
@@ -144,14 +144,14 @@ defaultValue="undefined"
 
 ## Returned values
 
-### `phone`
+### `inputValue`
 
 <PropDescription
 type="string"
 description="Formatted phone string. Value that should be rendered inside input element."
 />
 
-### `e164Phone`
+### `phone`
 
 <PropDescription
 type="string"

--- a/packages/docs/docs/04-Advanced Usage/02-useWithUiLibs.md
+++ b/packages/docs/docs/04-Advanced Usage/02-useWithUiLibs.md
@@ -50,7 +50,7 @@ export const MuiPhone = ({ value, onChange, ...restProps }) => {
       value,
       countries: defaultCountries,
       onChange: (data) => {
-        onChange(data.e164Phone);
+        onChange(data.phone);
       },
     });
 
@@ -166,13 +166,13 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
   onChange,
   ...restProps
 }) => {
-  const { phone, handlePhoneValueChange, inputRef, country, setCountry } =
+  const { inputValue, handlePhoneValueChange, inputRef, country, setCountry } =
     usePhoneInput({
       defaultCountry: 'us',
       value,
       countries: defaultCountries,
       onChange: (data) => {
-        onChange(data.e164Phone);
+        onChange(data.phone);
       },
     });
 
@@ -182,7 +182,7 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
       label="Phone number"
       color="primary"
       placeholder="Phone number"
-      value={phone}
+      value={inputValue}
       onChange={handlePhoneValueChange}
       type="tel"
       inputRef={inputRef}

--- a/packages/docs/docs/05-Migrations/04-migrate-to-v4.md
+++ b/packages/docs/docs/05-Migrations/04-migrate-to-v4.md
@@ -32,7 +32,7 @@ E.164 format phone returned in callback even if `disabledDialCodeAndPrefix` was 
 
 `onChange` callback type is changed: <br/>
 Before: `(phone: string, country: CountryIso2) => void`<br/>
-After: `(phone: string, data: { country: ParsedCountry, displayValue: string }) => void`.
+After: `(phone: string, data: { country: ParsedCountry, inputValue: string }) => void`.
 
 The second argument is now an object that contains additional information about the phone.
 

--- a/packages/docs/docs/05-Migrations/04-migrate-to-v4.md
+++ b/packages/docs/docs/05-Migrations/04-migrate-to-v4.md
@@ -7,13 +7,25 @@ New features and bug fixes will be pushed only to v4.
 
 :::
 
+## usePhoneInput return properties renamed
+
+- `phone` is renamed to `inputValue`
+- `e164Phone` is renamed to `phone`
+
+Now `phone` stands for E.164 formatted phone, and `inputValue` stands for string that is rendered inside input element.
+
+:::warning
+The hook still returns the `phone` value, but its value purpose has been changed.<br/>
+Please update values if you were using `usePhoneInput` hook.
+:::
+
 ## Added support for multiple masks per country
 
 Now country format mask can be dynamic, so country data type have been changed. You can check the new [Country Data Type](/docs/Usage/ModifyCountries#country-data-type).
 
 ## Switched to E.164 format
 
-Now `onChange` callback returns phone in E.164 format by default. New `e164Phone` return value was also provided to `usePhoneInput` hook.
+Now `onChange` callback returns phone in E.164 format by default. New `phone` return value was also provided to `usePhoneInput` hook.
 E.164 format phone returned in callback even if `disabledDialCodeAndPrefix` was set to `true`.
 
 ## Second argument of onChange callback is now an object

--- a/packages/docs/src/components/MuiPhone/MuiPhone.tsx
+++ b/packages/docs/src/components/MuiPhone/MuiPhone.tsx
@@ -32,13 +32,13 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
   onChange,
   ...restProps
 }) => {
-  const { phone, handlePhoneValueChange, inputRef, country, setCountry } =
+  const { inputValue, handlePhoneValueChange, inputRef, country, setCountry } =
     usePhoneInput({
       defaultCountry: 'us',
       value,
       countries: defaultCountries,
       onChange: (data) => {
-        onChange(data.e164Phone);
+        onChange(data.phone);
       },
     });
 
@@ -48,7 +48,7 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
       label="Phone number"
       color="primary"
       placeholder="Phone number"
-      value={phone}
+      value={inputValue}
       onChange={handlePhoneValueChange}
       type="tel"
       inputRef={inputRef}

--- a/packages/docs/src/components/MuiPhone/MuiPhoneJSX.jsx
+++ b/packages/docs/src/components/MuiPhone/MuiPhoneJSX.jsx
@@ -21,13 +21,13 @@ import {
 } from 'react-international-phone';
 
 export const MuiPhoneJsx = ({ value, onChange, ...restProps }) => {
-  const { phone, handlePhoneValueChange, inputRef, country, setCountry } =
+  const { inputValue, handlePhoneValueChange, inputRef, country, setCountry } =
     usePhoneInput({
       defaultCountry: 'us',
       value,
       countries: defaultCountries,
       onChange: (data) => {
-        onChange(data.e164Phone);
+        onChange(data.phone);
       },
     });
 
@@ -37,7 +37,7 @@ export const MuiPhoneJsx = ({ value, onChange, ...restProps }) => {
       label="Phone number"
       color="primary"
       placeholder="Phone number"
-      value={phone}
+      value={inputValue}
       onChange={handlePhoneValueChange}
       type="tel"
       inputRef={inputRef}

--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -76,22 +76,22 @@ describe('PhoneInput', () => {
       fireEvent.change(getInput(), { target: { value: '38099' } });
       expect(onChange.mock.calls.length).toBe(1);
       expect(onChange.mock.calls[0][0]).toBe('+38099');
-      expect(onChange.mock.calls[0][1].displayValue).toBe('+380 (99) ');
+      expect(onChange.mock.calls[0][1].inputValue).toBe('+380 (99) ');
 
       fireEvent.change(getInput(), { target: { value: '+380 (99) 999' } });
       expect(onChange.mock.calls.length).toBe(2);
       expect(onChange.mock.calls[1][0]).toBe('+38099999');
-      expect(onChange.mock.calls[1][1].displayValue).toBe('+380 (99) 999 ');
+      expect(onChange.mock.calls[1][1].inputValue).toBe('+380 (99) 999 ');
 
       fireEvent.change(getInput(), { target: { value: '' } });
       expect(onChange.mock.calls.length).toBe(3);
       expect(onChange.mock.calls[2][0]).toBe('');
-      expect(onChange.mock.calls[2][1].displayValue).toBe('');
+      expect(onChange.mock.calls[2][1].inputValue).toBe('');
 
       fireEvent.change(getInput(), { target: { value: '+1 403 555-6666' } });
       expect(onChange.mock.calls.length).toBe(4);
       expect(onChange.mock.calls[3][0]).toBe('+14035556666');
-      expect(onChange.mock.calls[3][1].displayValue).toBe('+1 (403) 555-6666');
+      expect(onChange.mock.calls[3][1].inputValue).toBe('+1 (403) 555-6666');
     });
 
     test('should call onChange on initialization (value is not in e164 format)', () => {
@@ -165,20 +165,20 @@ describe('PhoneInput', () => {
       );
       expect(onChange.mock.calls.length).toBe(1);
       expect(onChange.mock.calls[0][0]).toBe('+1');
-      expect(onChange.mock.calls[0][1].displayValue).toBe('+1 ');
-      expect(onChange.mock.calls[0][1].displayValue).toBe(getInput().value);
+      expect(onChange.mock.calls[0][1].inputValue).toBe('+1 ');
+      expect(onChange.mock.calls[0][1].inputValue).toBe(getInput().value);
 
       fireEvent.change(getInput(), { target: { value: '+38099' } });
       expect(onChange.mock.calls.length).toBe(2);
       expect(onChange.mock.calls[1][0]).toBe('+38099');
-      expect(onChange.mock.calls[1][1].displayValue).toBe('+380 (99) ');
-      expect(onChange.mock.calls[1][1].displayValue).toBe(getInput().value);
+      expect(onChange.mock.calls[1][1].inputValue).toBe('+380 (99) ');
+      expect(onChange.mock.calls[1][1].inputValue).toBe(getInput().value);
 
       fireEvent.change(getInput(), { target: { value: '+38099 99' } });
       expect(onChange.mock.calls.length).toBe(3);
       expect(onChange.mock.calls[2][0]).toBe('+3809999');
-      expect(onChange.mock.calls[2][1].displayValue).toBe('+380 (99) 99');
-      expect(onChange.mock.calls[2][1].displayValue).toBe(getInput().value);
+      expect(onChange.mock.calls[2][1].inputValue).toBe('+380 (99) 99');
+      expect(onChange.mock.calls[2][1].inputValue).toBe(getInput().value);
 
       // undo
       fireEvent.keyDown(getInput(), {
@@ -189,8 +189,8 @@ describe('PhoneInput', () => {
       });
       expect(onChange.mock.calls.length).toBe(4);
       expect(onChange.mock.calls[3][0]).toBe('+38099');
-      expect(onChange.mock.calls[3][1].displayValue).toBe('+380 (99) ');
-      expect(onChange.mock.calls[3][1].displayValue).toBe(getInput().value);
+      expect(onChange.mock.calls[3][1].inputValue).toBe('+380 (99) ');
+      expect(onChange.mock.calls[3][1].inputValue).toBe(getInput().value);
 
       // redo
       fireEvent.keyDown(getInput(), {
@@ -201,8 +201,8 @@ describe('PhoneInput', () => {
       });
       expect(onChange.mock.calls.length).toBe(5);
       expect(onChange.mock.calls[4][0]).toBe('+3809999');
-      expect(onChange.mock.calls[4][1].displayValue).toBe('+380 (99) 99');
-      expect(onChange.mock.calls[4][1].displayValue).toBe(getInput().value);
+      expect(onChange.mock.calls[4][1].inputValue).toBe('+380 (99) 99');
+      expect(onChange.mock.calls[4][1].inputValue).toBe(getInput().value);
     });
 
     test('should return data object as second argument', () => {
@@ -212,7 +212,7 @@ describe('PhoneInput', () => {
       expect(onChange.mock.calls[0][0]).toBe('+1');
       expect(onChange.mock.calls[0][1]).toMatchObject({
         country: getCountry({ field: 'iso2', value: 'us' }),
-        displayValue: '+1 ',
+        inputValue: '+1 ',
       });
 
       fireEvent.change(getInput(), { target: { value: '+1234' } });
@@ -220,7 +220,7 @@ describe('PhoneInput', () => {
       expect(onChange.mock.calls[1][0]).toBe('+1234');
       expect(onChange.mock.calls[1][1]).toMatchObject({
         country: getCountry({ field: 'iso2', value: 'us' }),
-        displayValue: '+1 (234) ',
+        inputValue: '+1 (234) ',
       });
 
       fireEvent.change(getInput(), { target: { value: '+380991234567' } });
@@ -228,7 +228,7 @@ describe('PhoneInput', () => {
       expect(onChange.mock.calls[2][0]).toBe('+380991234567');
       expect(onChange.mock.calls[2][1]).toMatchObject({
         country: getCountry({ field: 'iso2', value: 'ua' }),
-        displayValue: '+380 (99) 123 45 67',
+        inputValue: '+380 (99) 123 45 67',
       });
     });
   });

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -88,6 +88,11 @@ export type PhoneInputRefType =
   | null
   | (HTMLInputElement & {
       setCountry: (iso2: CountryIso2) => void;
+      state: {
+        phone: string;
+        inputValue: string;
+        country: ParsedCountry;
+      };
     });
 
 export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
@@ -121,6 +126,7 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
     ref,
   ) => {
     const {
+      phone,
       inputValue,
       inputRef,
       country,
@@ -151,9 +157,14 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
         return Object.assign(inputRef.current, {
           // extend input ref with additional properties
           setCountry,
+          state: {
+            phone,
+            inputValue,
+            country,
+          },
         });
       },
-      [inputRef, setCountry],
+      [inputRef, setCountry, phone, inputValue, country],
     );
 
     return (

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -54,14 +54,14 @@ export interface PhoneInputProps
 
   /**
    * @description Callback that calls on phone change
-   * @param e164Phone - New phone value in E.164 format.
+   * @param phone - New phone value in E.164 format.
    * @param meta - Additional information about the phone.
    * @param data.country - New phone country object.
    * @param data.displayValue - Value that is displayed in input element.
    * @default undefined
    */
   onChange?: (
-    e164Phone: string,
+    phone: string,
     meta: {
       country: ParsedCountry;
       displayValue: string;
@@ -120,18 +120,23 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
     },
     ref,
   ) => {
-    const { phone, inputRef, country, setCountry, handlePhoneValueChange } =
-      usePhoneInput({
-        value,
-        countries,
-        ...usePhoneInputConfig,
-        onChange: (data) => {
-          onChange?.(data.e164Phone, {
-            country: data.country,
-            displayValue: data.phone,
-          });
-        },
-      });
+    const {
+      inputValue,
+      inputRef,
+      country,
+      setCountry,
+      handlePhoneValueChange,
+    } = usePhoneInput({
+      value,
+      countries,
+      ...usePhoneInputConfig,
+      onChange: (data) => {
+        onChange?.(data.phone, {
+          country: data.country,
+          displayValue: data.inputValue,
+        });
+      },
+    });
 
     const showDialCodePreview =
       usePhoneInputConfig.disableDialCodeAndPrefix &&
@@ -181,7 +186,7 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
 
         <input
           onChange={handlePhoneValueChange}
-          value={phone}
+          value={inputValue}
           type="tel"
           ref={inputRef}
           className={buildClassNames({

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -57,14 +57,14 @@ export interface PhoneInputProps
    * @param phone - New phone value in E.164 format.
    * @param meta - Additional information about the phone.
    * @param data.country - New phone country object.
-   * @param data.displayValue - Value that is displayed in input element.
+   * @param data.inputValue - Value that is displayed in input element.
    * @default undefined
    */
   onChange?: (
     phone: string,
     meta: {
       country: ParsedCountry;
-      displayValue: string;
+      inputValue: string;
     },
   ) => void;
 
@@ -133,7 +133,7 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
       onChange: (data) => {
         onChange?.(data.phone, {
           country: data.country,
-          displayValue: data.inputValue,
+          inputValue: data.inputValue,
         });
       },
     });

--- a/src/stories/UiLibsExample/components/AntPhone.tsx
+++ b/src/stories/UiLibsExample/components/AntPhone.tsx
@@ -13,7 +13,7 @@ export const AntPhone: React.FC<AntPhoneProps> = ({ value, onChange }) => {
     defaultCountry: 'us',
     value,
     onChange: (data) => {
-      onChange(data.e164Phone);
+      onChange(data.phone);
     },
   });
 
@@ -53,9 +53,11 @@ export const AntPhone: React.FC<AntPhoneProps> = ({ value, onChange }) => {
         <Input
           placeholder="Phone number"
           type="tel"
-          value={phoneInput.phone}
+          value={phoneInput.inputValue}
           onChange={phoneInput.handlePhoneValueChange}
           ref={inputRef}
+          name="phone"
+          autoComplete="tel"
         />
       </Space.Compact>
     </div>

--- a/src/stories/UiLibsExample/components/ChakraPhone.tsx
+++ b/src/stories/UiLibsExample/components/ChakraPhone.tsx
@@ -16,7 +16,7 @@ export const ChakraPhone: React.FC<ChakraPhoneProps> = ({
     defaultCountry: 'us',
     value,
     onChange: (data) => {
-      onChange(data.e164Phone);
+      onChange(data.phone);
     },
   });
 
@@ -36,7 +36,7 @@ export const ChakraPhone: React.FC<ChakraPhoneProps> = ({
           placeholder="Phone number"
           type="tel"
           color="primary"
-          value={phoneInput.phone}
+          value={phoneInput.inputValue}
           onChange={phoneInput.handlePhoneValueChange}
           width={200}
           ref={phoneInput.inputRef}

--- a/src/stories/UiLibsExample/components/MuiPhone.tsx
+++ b/src/stories/UiLibsExample/components/MuiPhone.tsx
@@ -26,13 +26,13 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
   onChange,
   ...restProps
 }) => {
-  const { phone, handlePhoneValueChange, inputRef, country, setCountry } =
+  const { inputValue, handlePhoneValueChange, inputRef, country, setCountry } =
     usePhoneInput({
       defaultCountry: 'au',
       value,
       countries: defaultCountries,
       onChange: (data) => {
-        onChange(data.e164Phone);
+        onChange(data.phone);
       },
     });
 
@@ -42,7 +42,7 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
       label="Phone number"
       color="primary"
       placeholder="Phone number"
-      value={phone}
+      value={inputValue}
       onChange={handlePhoneValueChange}
       type="tel"
       inputRef={inputRef}

--- a/src/stories/UiLibsExample/components/MuiPhone2.tsx
+++ b/src/stories/UiLibsExample/components/MuiPhone2.tsx
@@ -5,12 +5,12 @@ import { CountrySelector, usePhoneInput } from '../../../index';
 import { MUIPhoneProps } from './MuiPhone';
 
 export const MuiPhone2: React.FC<MUIPhoneProps> = ({ value, onChange }) => {
-  const { phone, handlePhoneValueChange, inputRef, country, setCountry } =
+  const { inputValue, handlePhoneValueChange, inputRef, country, setCountry } =
     usePhoneInput({
       defaultCountry: 'us',
       value,
       onChange: (data) => {
-        onChange(data.e164Phone);
+        onChange(data.phone);
       },
     });
 
@@ -32,7 +32,7 @@ export const MuiPhone2: React.FC<MUIPhoneProps> = ({ value, onChange }) => {
       <TextField
         label="Phone number"
         color="primary"
-        value={phone}
+        value={inputValue}
         onChange={handlePhoneValueChange}
         inputRef={inputRef}
       />

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,7 +225,7 @@ type FormatConfig = Record<string, string> & {
 
 type CountryDataWithFormat = [
   ...BaseCountryData,
-  string | FormatConfig, // format
+  FormatConfig | string, // format
 ];
 
 type CountryDataWithOrder = [

--- a/src/utils/handlePhoneChange.ts
+++ b/src/utils/handlePhoneChange.ts
@@ -40,7 +40,7 @@ export function handlePhoneChange({
   disableFormatting,
 }: HandlePhoneChangeProps): {
   phone: string;
-  e164Phone: string;
+  inputValue: string;
   country: ParsedCountry;
 } {
   let inputPhone = value;
@@ -62,7 +62,7 @@ export function handlePhoneChange({
 
   const formatCountry = countryGuessResult?.country ?? country;
 
-  const phone = formatPhone(inputPhone, {
+  const inputValue = formatPhone(inputPhone, {
     prefix,
     mask: getActiveFormattingMask({
       phone: inputPhone,
@@ -84,16 +84,16 @@ export function handlePhoneChange({
       ? country
       : formatCountry;
 
-  const e164Phone = toE164({
+  const phone = toE164({
     phone: disableDialCodeAndPrefix
-      ? `${resultCountry.dialCode}${phone}`
-      : phone,
+      ? `${resultCountry.dialCode}${inputValue}`
+      : inputValue,
     prefix,
   });
 
   return {
     phone,
-    e164Phone,
+    inputValue,
     country: resultCountry,
   };
 }

--- a/src/utils/handleUserInput.ts
+++ b/src/utils/handleUserInput.ts
@@ -36,7 +36,7 @@ export const handleUserInput = (
   }: HandleUserInputOptions,
 ): {
   phone: string;
-  e164Phone: string;
+  inputValue: string;
   cursorPosition: number;
   country: ParsedCountry;
 } => {
@@ -68,8 +68,8 @@ export const handleUserInput = (
     userInput !== prefix
   ) {
     return {
-      phone: phoneBeforeInput,
-      e164Phone: toE164({
+      inputValue: phoneBeforeInput,
+      phone: toE164({
         phone: disableDialCodeAndPrefix
           ? `${country.dialCode}${phoneBeforeInput}`
           : phoneBeforeInput,
@@ -88,13 +88,13 @@ export const handleUserInput = (
     // was not inserted with ctrl+v
     !isInserted
   ) {
-    const phoneValue = userInput
+    const inputValue = userInput
       ? phoneBeforeInput
       : `${prefix}${country.dialCode}${charAfterDialCode}`;
 
     return {
-      phone: phoneValue,
-      e164Phone: toE164({ phone: phoneValue, prefix }),
+      inputValue,
+      phone: toE164({ phone: inputValue, prefix }),
       cursorPosition:
         prefix.length + country.dialCode.length + charAfterDialCode.length, // set cursor position after dial code
       country,
@@ -103,7 +103,7 @@ export const handleUserInput = (
 
   const {
     phone: newPhone,
-    e164Phone: newE164Phone,
+    inputValue: newInputValue,
     country: newCountry,
   } = handlePhoneChange({
     value: userInput,
@@ -126,7 +126,7 @@ export const handleUserInput = (
     cursorPositionAfterInput,
     phoneBeforeInput,
     phoneAfterInput: userInput,
-    phoneAfterFormatted: newPhone,
+    phoneAfterFormatted: newInputValue,
     leftOffset: forceDialCode
       ? prefix.length + country.dialCode.length + charAfterDialCode.length
       : 0,
@@ -135,7 +135,7 @@ export const handleUserInput = (
 
   return {
     phone: newPhone,
-    e164Phone: newE164Phone,
+    inputValue: newInputValue,
     cursorPosition: newCursorPosition,
     country: newCountry,
   };


### PR DESCRIPTION
## What has been done
- Renamed `displayValue` to `inputValue` in onChange
  - `onChange` now provides these values:
    ```ts
    phone: string,
    meta: {
      country: ParsedCountry;
      inputValue: string;
    }
    ```
- Renamed `phone` to `inputValue` in usePhoneInput return
- Renamed `e164Phone` to `phone`
- Added `state` ref property

