### PR TITLE
preferSelectedCountry parameter to control country guessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ yarn-error.log*
 
 # storybook
 storybook-static
+
+# IDE
+.idea

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -53,6 +53,12 @@ export interface PhoneInputProps
   flags?: CountrySelectorProps['flags'];
 
   /**
+   * @description when enabled, it will append the selected country dial code to the input value unless starts with `+`
+   * @default undefined
+   */
+  preferSelectedCountry?: boolean;
+
+  /**
    * @description Callback that calls on phone change
    * @param phone - New phone value in E.164 format.
    * @param meta - Additional information about the phone.

--- a/src/data/countryData.ts
+++ b/src/data/countryData.ts
@@ -144,7 +144,7 @@ export const defaultCountries: CountryData[] = [
   ['Gabon', 'ga', '241'],
   ['Gambia', 'gm', '220'],
   ['Georgia', 'ge', '995'],
-  ['Germany', 'de', '49', '.... ........'],
+  ['Germany', 'de', '49', '... .........'],
   ['Ghana', 'gh', '233'],
   ['Greece', 'gr', '30'],
   ['Grenada', 'gd', '1473'],

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -178,6 +178,12 @@ export const usePhoneInput = ({
      * useTimeout with 0ms provides issues when two keys are pressed same time
      */
     Promise.resolve().then(() => {
+      // workaround for safari autofocus bug:
+      // Check if the input is focused before setting the cursor, otherwise safari sometimes autofocuses on setSelectionRange
+      if (inputRef.current !== document?.activeElement) {
+        return;
+      }
+
       inputRef.current?.setSelectionRange(cursorPosition, cursorPosition);
     });
   };

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -180,7 +180,10 @@ export const usePhoneInput = ({
     Promise.resolve().then(() => {
       // workaround for safari autofocus bug:
       // Check if the input is focused before setting the cursor, otherwise safari sometimes autofocuses on setSelectionRange
-      if (inputRef.current !== document?.activeElement) {
+      if (
+        typeof window === 'undefined' ||
+        inputRef.current !== document?.activeElement
+      ) {
         return;
       }
 

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -87,6 +87,12 @@ export interface UsePhoneInputConfig {
   disableDialCodeAndPrefix?: boolean;
 
   /**
+   * @description When enabled, it will prepend the selected country dial code to the input value unless user input starts with `+`
+   * @default false
+   */
+  preferSelectedCountry?: boolean;
+
+  /**
    * @description Disable phone value mask formatting. All formatting characters will not be displayed, but the mask length will be preserved.
    * @default false
    */
@@ -126,6 +132,7 @@ export const defaultConfig: Required<
   disableDialCodePrefill: false,
   forceDialCode: false,
   disableDialCodeAndPrefix: false,
+  preferSelectedCountry: false,
   disableFormatting: false,
   countries: defaultCountries,
 };
@@ -142,6 +149,7 @@ export const usePhoneInput = ({
   disableDialCodePrefill = defaultConfig.disableDialCodePrefill,
   forceDialCode: forceDialCodeConfig = defaultConfig.forceDialCode,
   disableDialCodeAndPrefix = defaultConfig.disableDialCodeAndPrefix,
+  preferSelectedCountry = defaultConfig.preferSelectedCountry,
   disableFormatting = defaultConfig.disableFormatting,
   onChange,
   inputRef: inputRefProp,
@@ -158,6 +166,7 @@ export const usePhoneInput = ({
     defaultMask,
     countryGuessingEnabled,
     disableFormatting,
+    preferSelectedCountry,
   };
 
   const ref = useRef<HTMLInputElement | null>(null);
@@ -211,6 +220,7 @@ export const usePhoneInput = ({
           country: initialCountry,
           insertDialCodeOnEmpty: !disableDialCodePrefill,
           ...phoneFormattingConfig,
+          preferSelectedCountry: false,
         });
 
         setCursorPosition(inputValue.length);
@@ -365,6 +375,7 @@ export const usePhoneInput = ({
       country: fullCountry,
       insertDialCodeOnEmpty: !disableDialCodePrefill,
       ...phoneFormattingConfig,
+      preferSelectedCountry: false,
     });
 
     updateHistory({

--- a/src/utils/handlePhoneChange.ts
+++ b/src/utils/handlePhoneChange.ts
@@ -15,6 +15,7 @@ export interface PhoneFormattingConfig {
   defaultMask: string;
   countryGuessingEnabled: boolean;
   disableFormatting: boolean;
+  preferSelectedCountry: boolean;
 }
 
 interface HandlePhoneChangeProps extends PhoneFormattingConfig {
@@ -38,12 +39,24 @@ export function handlePhoneChange({
   defaultMask,
   countryGuessingEnabled,
   disableFormatting,
+  preferSelectedCountry,
 }: HandlePhoneChangeProps): {
   phone: string;
   inputValue: string;
   country: ParsedCountry;
 } {
   let inputPhone = value;
+
+  // if preferSelectedCountry is enabled, then we should prefill the already selected country dial code to prevent guessing
+  // slightly different from disableDialCodeAndPrefix as that also hides the dial code
+  if (
+    preferSelectedCountry &&
+    country?.dialCode &&
+    inputPhone &&
+    !inputPhone.startsWith(`${prefix}`)
+  ) {
+    inputPhone = `${prefix}${country.dialCode}${inputPhone}`;
+  }
 
   // make sure that inputPhone starts with dial code when dial code is disabled
   if (disableDialCodeAndPrefix) {

--- a/src/utils/handleUserInput.ts
+++ b/src/utils/handleUserInput.ts
@@ -33,6 +33,7 @@ export const handleUserInput = (
     defaultMask,
     disableFormatting,
     countries,
+    preferSelectedCountry,
   }: HandleUserInputOptions,
 ): {
   phone: string;
@@ -131,6 +132,7 @@ export const handleUserInput = (
     disableDialCodeAndPrefix,
     disableFormatting,
     defaultMask,
+    preferSelectedCountry,
   });
 
   const newCursorPosition = getCursorPosition({


### PR DESCRIPTION
## What has been done

Right now country guessing is a bit aggressive. 
Some people may try to input only the number without the country code when they see a flag already selected. Also sometimes browser autofill fills the number without country code  but the component tries to guess the country code anyway and makes the first digit of the local number to be the country code which is wrong.
For example, in Germany local number might look like 17123123123 which gets converted to +17123123123 as a US number even if we set the default country to Germany.
Without breaking the existing functionality I've added an additional parameter to prefer the already selected country. When enabled, it will append the number with the selected country code unless user starts with + (to intentionally change country code)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] Tests for the changes have been added (for bug fixes/features). // feel free to add tests
- [x] Docs have been added / updated (for bug fixes / features).

## Screenshots (if appropriate):
