### PR TITLE
Handle invalid country code passed in setCountry

### DIFF
--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -1169,7 +1169,7 @@ describe('PhoneInput', () => {
       expect(getInput().value).toBe('+1 1234567890');
     });
 
-    test('should remove handle default mask', async () => {
+    test('should handle default mask', async () => {
       const user = userEvent.setup({ delay: null });
 
       render(<PhoneInput disableFormatting defaultMask="(...) ... ... ..." />);
@@ -1209,6 +1209,10 @@ describe('PhoneInput', () => {
     });
 
     test('should support custom setCountry method', async () => {
+      const logSpy = jest
+        .spyOn(global.console, 'error')
+        .mockImplementation(() => null);
+
       const ref = React.createRef<PhoneInputRefType>();
 
       render(<PhoneInput ref={ref} />);
@@ -1216,6 +1220,16 @@ describe('PhoneInput', () => {
 
       act(() => ref.current?.setCountry('ua'));
       expect(getInput().value).toBe('+380 ');
+
+      // should log error if not valid country code provided
+      act(() => ref.current?.setCountry('test-country'));
+      expect(getInput().value).toBe('+380 ');
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(
+        '[react-international-phone]: can not find a country with "test-country" iso2 code',
+      );
+      logSpy.mockRestore();
     });
 
     test('should support custom state property', async () => {

--- a/src/hooks/usePhoneInput.ts
+++ b/src/hooks/usePhoneInput.ts
@@ -309,7 +309,12 @@ export const usePhoneInput = ({
       field: 'iso2',
       countries,
     });
-    if (!newCountry) return;
+    if (!newCountry) {
+      console.error(
+        `[react-international-phone]: can not find a country with "${countryIso2}" iso2 code`,
+      );
+      return;
+    }
 
     const inputValue = disableDialCodeAndPrefix
       ? ''


### PR DESCRIPTION
## What has been done
- Log error to console if not existed country code is passed to `setCountry`

