### PR TITLE
MUI Example Updated

### DIFF
--- a/packages/docs/docs/04-Advanced Usage/02-useWithUiLibs.md
+++ b/packages/docs/docs/04-Advanced Usage/02-useWithUiLibs.md
@@ -139,42 +139,25 @@ export const MuiPhone = ({ value, onChange, ...restProps }) => {
 ```tsx
 import 'react-international-phone/style.css';
 
-import {
-  BaseTextFieldProps,
-  InputAdornment,
-  MenuItem,
-  Select,
-  TextField,
-  Typography,
-} from '@mui/material';
-import React from 'react';
-import {
-  CountryIso2,
-  defaultCountries,
-  FlagImage,
-  parseCountry,
-  usePhoneInput,
-} from 'react-international-phone';
+import InputAdornment from '@mui/material/InputAdornment';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import TextField, { type BaseTextFieldProps } from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { FlagImage, defaultCountries, parseCountry, usePhoneInput, type CountryIso2 } from 'react-international-phone';
+import { type UsePhoneInputConfig } from 'react-international-phone/build/hooks/usePhoneInput';
 
-export interface MUIPhoneProps extends BaseTextFieldProps {
-  value: string;
-  onChange: (phone: string) => void;
-}
+type MUIPhoneProps = BaseTextFieldProps & Pick<UsePhoneInputConfig, 'onChange' | 'value'>;
 
-export const MuiPhone: React.FC<MUIPhoneProps> = ({
-  value,
-  onChange,
-  ...restProps
-}) => {
-  const { inputValue, handlePhoneValueChange, inputRef, country, setCountry } =
-    usePhoneInput({
-      defaultCountry: 'us',
-      value,
-      countries: defaultCountries,
-      onChange: (data) => {
-        onChange(data.phone);
-      },
-    });
+export default function InternationalPhoneField({ value, onChange, ...restProps }: MUIPhoneProps): React.ReactElement {
+  const { inputValue, handlePhoneValueChange, inputRef, country, setCountry } = usePhoneInput({
+    countries: defaultCountries,
+    defaultCountry: 'us',
+    onChange,
+    value,
+  });
 
   return (
     <TextField
@@ -188,25 +171,9 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
       inputRef={inputRef}
       InputProps={{
         startAdornment: (
-          <InputAdornment
-            position="start"
-            style={{ marginRight: '2px', marginLeft: '-8px' }}
-          >
+          <InputAdornment position="start">
             <Select
-              MenuProps={{
-                style: {
-                  height: '300px',
-                  width: '360px',
-                  top: '10px',
-                  left: '-34px',
-                },
-                transformOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left',
-                },
-              }}
               sx={{
-                width: 'max-content',
                 // Remove default outline (display only on focus)
                 fieldset: {
                   display: 'none',
@@ -216,30 +183,19 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
                     display: 'block',
                   },
                 },
-                // Update default spacing
-                '.MuiSelect-select': {
-                  padding: '8px',
-                  paddingRight: '24px !important',
-                },
-                svg: {
-                  right: 0,
-                },
               }}
-              value={country}
-              onChange={(e) => setCountry(e.target.value as CountryIso2)}
-              renderValue={(value) => (
-                <FlagImage iso2={value} style={{ display: 'flex' }} />
-              )}
+              value={country.iso2}
+              onChange={(e) => setCountry(e.target.value)}
+              renderValue={(value: CountryIso2) => <FlagImage iso2={value} style={{ display: 'flex' }} />}
             >
               {defaultCountries.map((c) => {
                 const country = parseCountry(c);
                 return (
                   <MenuItem key={country.iso2} value={country.iso2}>
-                    <FlagImage
-                      iso2={country.iso2}
-                      style={{ marginRight: '8px' }}
-                    />
-                    <Typography marginRight="8px">{country.name}</Typography>
+                    <ListItemIcon>
+                      <FlagImage iso2={country.iso2} />
+                    </ListItemIcon>
+                    <ListItemText>{country.name}</ListItemText>
                     <Typography color="gray">+{country.dialCode}</Typography>
                   </MenuItem>
                 );
@@ -251,7 +207,7 @@ export const MuiPhone: React.FC<MUIPhoneProps> = ({
       {...restProps}
     />
   );
-};
+}
 ```
 
   </TabItem>


### PR DESCRIPTION
Removed non-MUI styles and the demo is still working fine. Reason:
Because when using MUI, we often inherit styles from the global theme instead of writing inline styles.

## What has been done

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] Docs have been added / updated (for bug fixes / features).
