### PR TITLE
feat(component): add "onKeyDown" prop

### DIFF
--- a/packages/docs/docs/02-Usage/01-PhoneInput.md
+++ b/packages/docs/docs/02-Usage/01-PhoneInput.md
@@ -38,6 +38,14 @@ description="Phone value."
 defaultValue={'""'}
 />
 
+### `onKeyDown`
+
+<PropDescription
+type="KeyboardEventHandler | undefined"
+description="Callback that calls when a key is pressed in the input element"
+defaultValue="undefined"
+/>
+
 ### `onChange`
 
 <PropDescription

--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -239,6 +239,17 @@ describe('PhoneInput', () => {
     });
   });
 
+  describe('onKeyDown', () => {
+    test("should call onKeyDown when input element's associated event is called", async () => {
+      const onKeyDown = jest.fn();
+      render(
+        <PhoneInput value="+1" defaultCountry="us" onKeyDown={onKeyDown} />,
+      );
+      fireEvent.keyDown(getInput());
+      expect(onKeyDown.mock.calls.length).toBe(1);
+    });
+  });
+
   describe('country flag', () => {
     test('should set flag on initial render', () => {
       render(<PhoneInput value="+1" defaultCountry="ca" />);

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -1,6 +1,10 @@
 import './PhoneInput.style.scss';
 
-import React, { forwardRef, useImperativeHandle } from 'react';
+import React, {
+  forwardRef,
+  KeyboardEventHandler,
+  useImperativeHandle,
+} from 'react';
 
 import { defaultCountries } from '../../data/countryData';
 import { usePhoneInput, UsePhoneInputConfig } from '../../hooks/usePhoneInput';
@@ -75,6 +79,12 @@ export interface PhoneInputProps
   ) => void;
 
   /**
+   * @description Pass-through of onKeyDown event
+   * @default undefined
+   */
+  onKeyDown?: KeyboardEventHandler | undefined;
+
+  /**
    * @description Default input component props
    * @default undefined
    */
@@ -106,6 +116,7 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
     {
       value,
       onChange,
+      onKeyDown,
       countries = defaultCountries,
       preferredCountries = [],
       hideDropdown,
@@ -210,6 +221,7 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
 
         <input
           onChange={handlePhoneValueChange}
+          onKeyDown={onKeyDown}
           value={inputValue}
           type="tel"
           ref={inputRef}


### PR DESCRIPTION
## What has been done

This adds an `onKeyDown` event that is a pass-through for the associated event from the input element, allowing users to listen to enter key events.

## Checklist before requesting a review

- [x] I have read the [contributing doc](https://github.com/goveo/react-international-phone/blob/master/CONTRIBUTING.md) before submitting this PR.
- [x] Commit titles correspond to the [convention](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have performed a self-review of my code.
- [x] Tests for the changes have been added (for bug fixes/features).
- [x] Docs have been added / updated (for bug fixes / features).