### PR TITLE
feat(countryselector button props): enables passing through props to …

### DIFF
--- a/src/components/CountrySelector/CountrySelector.test.tsx
+++ b/src/components/CountrySelector/CountrySelector.test.tsx
@@ -173,4 +173,19 @@ describe('CountrySelector', () => {
       expect(getCountrySelectorDropdown()).toBeVisible();
     });
   });
+
+  describe('buttons props', () => {
+    test('should set button id', () => {
+      render(
+        <CountrySelector
+          selectedCountry="us"
+          buttonProps={{ id: 'country-selector-button' }}
+        />,
+      );
+      expect(getCountrySelector()).toHaveAttribute(
+        'id',
+        'country-selector-button',
+      );
+    });
+  });
 });

--- a/src/components/CountrySelector/CountrySelector.tsx
+++ b/src/components/CountrySelector/CountrySelector.tsx
@@ -47,11 +47,18 @@ type RenderButtonWrapperRootProps = {
   | 'aria-expanded'
 >;
 
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
 export interface CountrySelectorProps extends CountrySelectorStyleProps {
   selectedCountry: CountryIso2;
   onSelect?: CountrySelectorDropdownProps['onSelect'];
   disabled?: boolean;
   hideDropdown?: boolean;
+  /**
+   * @description Default button element props
+   * @default undefined
+   */
+  buttonProps?: ButtonProps;
   countries?: CountryData[];
   preferredCountries?: CountryIso2[];
   flags?: CountrySelectorDropdownProps['flags'];
@@ -66,6 +73,7 @@ export const CountrySelector: React.FC<CountrySelectorProps> = ({
   onSelect,
   disabled,
   hideDropdown,
+  buttonProps,
   countries = defaultCountries,
   preferredCountries = [],
   flags,
@@ -169,6 +177,7 @@ export const CountrySelector: React.FC<CountrySelectorProps> = ({
         })}
         data-country={selectedCountry}
         style={styleProps.buttonStyle}
+        {...buttonProps}
       >
         {buttonContent}
       </button>

--- a/src/components/PhoneInput/PhoneInput.test.tsx
+++ b/src/components/PhoneInput/PhoneInput.test.tsx
@@ -1134,6 +1134,19 @@ describe('PhoneInput', () => {
     expect(getCountrySelector()).toHaveAttribute('data-country', 'gr');
   });
 
+  test('should set country selector button id', () => {
+    render(
+      <PhoneInput
+        defaultCountry="af"
+        countrySelectorButtonProps={{ id: 'country-selector-button' }}
+      />,
+    );
+    expect(getCountrySelector()).toHaveAttribute(
+      'id',
+      'country-selector-button',
+    );
+  });
+
   test('should display input value on every country', () => {
     render(
       <PhoneInput defaultCountry={parseCountry(defaultCountries[0]).iso2} />,

--- a/src/components/PhoneInput/PhoneInput.tsx
+++ b/src/components/PhoneInput/PhoneInput.tsx
@@ -28,6 +28,7 @@ export interface PhoneInputStyleProps {
 }
 
 type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+type CountrySelectorButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 export interface PhoneInputProps
   extends Omit<UsePhoneInputConfig, 'onChange'>,
@@ -79,7 +80,11 @@ export interface PhoneInputProps
    * @default undefined
    */
   inputProps?: InputProps;
-
+  /**
+   * @description Default country selector button element props
+   * @default undefined
+   */
+  countrySelectorButtonProps?: CountrySelectorButtonProps;
   // pass most used input props as top level props for easy integration
   onFocus?: InputProps['onFocus'];
   onBlur?: InputProps['onBlur'];
@@ -121,6 +126,7 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
       dialCodePreviewStyleProps,
 
       inputProps,
+      countrySelectorButtonProps,
       placeholder,
       disabled,
       name,
@@ -196,6 +202,7 @@ export const PhoneInput = forwardRef<PhoneInputRefType, PhoneInputProps>(
           preferredCountries={preferredCountries}
           disabled={disabled}
           hideDropdown={hideDropdown}
+          buttonProps={countrySelectorButtonProps}
           {...countrySelectorStyleProps}
         />
 


### PR DESCRIPTION
…the country selector button

## What has been done
Adds a new prop to the PhoneInput component called countrySelectorButtonProps which allows the developer to pass in relevant props directly to the button element in the CountrySelector component

## Checklist before requesting a review

- [ ] I have read the [contributing doc](https://github.com/goveo/react-international-phone/blob/master/CONTRIBUTING.md) before submitting this PR.
- [ ] Commit titles correspond to the [convention](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have performed a self-review of my code.
- [ ] Tests for the changes have been added (for bug fixes/features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Screenshots (if appropriate):
