### PR TITLE
feat(country): add gibraltar to country selector

### DIFF
--- a/src/data/countryData.ts
+++ b/src/data/countryData.ts
@@ -150,6 +150,7 @@ export const defaultCountries: CountryData[] = [
   ['Georgia', 'ge', '995'],
   ['Germany', 'de', '49', '... .........'],
   ['Ghana', 'gh', '233'],
+  ['Gibraltar','gib','350', '.... ... .....']
   ['Greece', 'gr', '30'],
   ['Greenland', 'gl', '299', '.. .. ..'],
   ['Grenada', 'gd', '1473'],


### PR DESCRIPTION
Add Gibraltar to the country selector with the current prefix +350 and mask *** *****

## What has been done

## Checklist before requesting a review

- [X] I have read the [contributing doc](https://github.com/goveo/react-international-phone/blob/master/CONTRIBUTING.md) before submitting this PR.
- [X] Commit titles correspond to the [convention](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have performed a self-review of my code.
- [ ] Tests for the changes have been added (for bug fixes/features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Screenshots (if appropriate):
