### PR TITLE
fix(country-data): update Philippines phone format

### DIFF
--- a/src/data/countryData.ts
+++ b/src/data/countryData.ts
@@ -243,7 +243,7 @@ export const defaultCountries: CountryData[] = [
   ['Papua New Guinea', 'pg', '675'],
   ['Paraguay', 'py', '595'],
   ['Peru', 'pe', '51'],
-  ['Philippines', 'ph', '63', '.... .......'],
+  ['Philippines', 'ph', '63', '... ... ....'],
   ['Poland', 'pl', '48', '...-...-...'],
   ['Portugal', 'pt', '351'],
   ['Puerto Rico', 'pr', '1', '(...) ...-....', 3, ['787', '939']],


### PR DESCRIPTION
## What has been done
Updated the Philippines phone format based on the mobile number format of `+63 xxx xxx xxxx`
[Reference](https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Philippines)

## Checklist before requesting a review

- [x] I have read the [contributing doc](https://github.com/goveo/react-international-phone/blob/master/CONTRIBUTING.md) before submitting this PR.
- [x] Commit titles correspond to the [convention](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have performed a self-review of my code.
- [x] Tests for the changes have been added (for bug fixes/features). (N/A)
- [x] Docs have been added / updated (for bug fixes / features). (N/A)
