### PR TITLE
fix: allow finland number to be 10 chars

### DIFF
--- a/src/data/countryData.ts
+++ b/src/data/countryData.ts
@@ -142,7 +142,7 @@ export const defaultCountries: CountryData[] = [
   ['Ethiopia', 'et', '251', '.. ... ....'],
   ['Faroe Islands', 'fo', '298', '.. .. ..'],
   ['Fiji', 'fj', '679'],
-  ['Finland', 'fi', '358', '.. ... .. ..'],
+  ['Finland', 'fi', '358', '.. ... ... ..'],
   ['France', 'fr', '33', '. .. .. .. ..'],
   ['French Guiana', 'gf', '594', '... .. .. ..'],
   [


### PR DESCRIPTION
## What has been done
Allow Finland to have length of 10 characters

## Checklist before requesting a review

- [x] I have read the [contributing doc](https://github.com/ybrusentsov/react-international-phone/blob/master/CONTRIBUTING.md) before submitting this PR.
- [x] Commit titles correspond to the [convention](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have performed a self-review of my code.
- [x] Tests for the changes have been added (for bug fixes/features).
- [x] Docs have been added / updated (for bug fixes / features).

## Screenshots (if appropriate):
