### PR TITLE
fix(countrydata.ts): support both mobile and landline phone formats for Brazil

### DIFF
--- a/src/data/countryData.ts
+++ b/src/data/countryData.ts
@@ -64,7 +64,15 @@ export const defaultCountries: CountryData[] = [
   ['Bolivia', 'bo', '591'],
   ['Bosnia and Herzegovina', 'ba', '387'],
   ['Botswana', 'bw', '267'],
-  ['Brazil', 'br', '55', '(..) .....-....'],
+  [
+    'Brazil',
+    'br',
+    '55',
+    {
+      default: '(..) ....-....',
+      '/^\\d{2}9/': '(..) .....-....',
+    },
+  ],
   ['British Indian Ocean Territory', 'io', '246'],
   ['Brunei', 'bn', '673'],
   ['Bulgaria', 'bg', '359'],


### PR DESCRIPTION
## What has been done
Added support for landline phone format in Brazil. Previously, all numbers 
were formatted only as mobile phones, but Brazil has two distinct patterns:

- Mobile: `(XX) XXXXX-XXXX` (9 digits)
- Landline: `(XX) XXXX-XXXX` (8 digits).

## Checklist before requesting a review

- [x] I have read the [contributing doc](https://github.com/ybrusentsov/react-international-phone/blob/master/CONTRIBUTING.md) before submitting this PR.
- [x] Commit titles correspond to the [convention](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have performed a self-review of my code.
- [ ] Tests for the changes have been added (for bug fixes/features).
- [ ] Docs have been added / updated (for bug fixes / features).

